### PR TITLE
DocumentDB VS Code Extension Section (how to connect)

### DIFF
--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -609,30 +609,38 @@ docker image rm -f ghcr.io/microsoft/documentdb/documentdb-local:latest || echo 
                           <li className="flex items-start">
                             <span className="text-blue-400 mr-3 mt-1">•</span>
                             <span>
-                              Click the DocumentDB icon in the VS Code sidebar
+                              Locate and select the DocumentDB icon in the primary VS Code sidebar on the left-hand side.
                             </span>
                           </li>
                           <li className="flex items-start">
                             <span className="text-blue-400 mr-3 mt-1">•</span>
-                            <span>Click "Add New Connection"</span>
-                          </li>
-                          <li className="flex items-start">
-                            <span className="text-blue-400 mr-3 mt-1">•</span>
-                            <span>
-                              On the navigation bar, click on "Connection
-                              String"
-                            </span>
-                          </li>
-                          <li className="flex items-start">
-                            <span className="text-blue-400 mr-3 mt-1">•</span>
-                            <span>Paste your connection string:</span>
+                            <div>
+                              <span className="block mb-2">Add a new connection to your DocumentDB:</span>
+                              <ul className="space-y-1 ml-4">
+                                <li className="flex items-start">
+                                  <span className="text-gray-500 mr-2 mt-1">•</span>
+                                  <span>In the DocumentDB Connections area, locate and expand the DocumentDB Local node.</span>
+                                </li>
+                                <li className="flex items-start">
+                                  <span className="text-gray-500 mr-2 mt-1">•</span>
+                                  <span>Select the New Local Connection option.</span>
+                                </li>
+                                <li className="flex items-start">
+                                  <span className="text-gray-500 mr-2 mt-1">•</span>
+                                  <span>Confirm the port (default value 10260), username, password, and choose the Disable TLS/SSL option.</span>
+                                </li>
+                                <li className="flex items-start">
+                                  <span className="text-gray-500 mr-2 mt-1">•</span>
+                                  <span><strong>Note:</strong> TLS/SSL can be enabled, but this walkthrough skips those steps for simplicity.</span>
+                                </li>
+                                <li className="flex items-start">
+                                  <span className="text-gray-500 mr-2 mt-1">•</span>
+                                  <span>A new DocumentDB Local entry will be added and listed in your DocumentDB Connections area.</span>
+                                </li>
+                              </ul>
+                            </div>
                           </li>
                         </ul>
-                        <div className="bg-neutral-900/50 rounded-lg p-4 border border-neutral-600/30">
-                          <code className="text-green-400 font-mono text-sm break-all">
-                            mongodb://&lt;YOUR_USERNAME&gt;:&lt;YOUR_PASSWORD&gt;@localhost:10260/?tls=true&tlsAllowInvalidCertificates=true&authMechanism=SCRAM-SHA-256
-                          </code>
-                        </div>
                       </div>
 
                       <div>


### PR DESCRIPTION
This pull request updates the setup instructions for connecting to DocumentDB in the VS Code extension documentation. The changes improve clarity and provide more detailed, step-by-step guidance for users.

Improvements to documentation clarity and guidance:

* Updated the instruction to locate and select the DocumentDB icon in the VS Code sidebar, making the location more explicit for users.
* Replaced a single "Add New Connection" step with a detailed, multi-step nested list describing how to add a new local connection, including expanding the DocumentDB Local node, selecting the new connection option, confirming port and credentials, and noting TLS/SSL settings.
* Added a note clarifying that TLS/SSL can be enabled but is skipped in the walkthrough for simplicity.
* Clarified that a new DocumentDB Local entry will be added and listed in the DocumentDB Connections area after setup.

<img width="754" height="319" alt="image" src="https://github.com/user-attachments/assets/96766fca-ad25-42c0-b716-34df56ef8874" />
