### PR TITLE
Add generated `aggregation` commands

### DIFF
--- a/reference/command/aggregation/aggregate.yml
+++ b/reference/command/aggregation/aggregate.yml
@@ -1,0 +1,114 @@
+type: command
+category: aggregation
+name: aggregate
+description: |-
+  The aggregate command is used to process data records and return computed results.
+summary: |-
+  The `aggregate` command is used to process data records and return computed results. It performs operations on the data, such as filtering, grouping, and sorting, and can transform the data in various ways. The `aggregate` command is highly versatile and is commonly used for data analysis and reporting.
+syntax: |-
+  db.collection.aggregate(pipeline, options)
+parameters:
+- name: pipeline
+  required: true
+  description: |-
+    An array of aggregation stages that process and transform the data.
+- name: options
+  required: false
+  description: |-
+    Optional. Specifies more options for the aggregation, such as `explain`, `allowDiskUse`, and `cursor`.
+examples:
+  items:
+  - title: Calculate total sales by category
+    description: |-
+      This example demonstrates how to calculate the total sales for each category in the `stores` collection.
+    query: |-
+      db.stores.aggregate([
+        {
+          $unwind: "$sales.salesByCategory"
+        },
+        {
+          $group: {
+            _id: "$sales.salesByCategory.categoryName",
+            totalSales: { $sum: "$sales.salesByCategory.totalSales" }
+          }
+        }
+      ])
+    output:
+      value: |-
+        [
+          { _id: 'Christmas Trees', totalSales: 3147281 },
+          { _id: 'Nuts', totalSales: 3002332 },
+          { _id: 'Camping Tables', totalSales: 4431667 }
+        ]
+  - title: Find stores with full-time staff greater than 10
+    description: |-
+      This example shows how to filter stores where the number of full-time staff is greater than 10.
+    query: |-
+      db.stores.aggregate([
+        {
+          $match: {
+            "staff.totalStaff.fullTime": { $gt: 10 }
+          }
+        }
+      ])
+    output:
+      value: |-
+        [
+          {
+            _id: '7954bd5c-9ac2-4c10-bb7a-2b79bd0963c5',
+            name: "Lenore's DJ Equipment Store",
+            location: { lat: -9.9399, lon: -0.334 },
+            staff: { totalStaff: { fullTime: 18, partTime: 7 } },
+            sales: {
+              totalSales: 35911,
+              salesByCategory: [ { categoryName: 'DJ Headphones', totalSales: 35911 } ]
+            },
+            promotionEvents: [
+              {
+                discounts: [
+                  { categoryName: 'DJ Turntables', discountPercentage: 18 },
+                  { categoryName: 'DJ Mixers', discountPercentage: 15 }
+                ]
+              }
+            ],
+            tag: [ '#SeasonalSale', '#FreeShipping', '#MembershipDeals' ]
+          }
+        ]
+  - title: List all promotion events with discounts greater than 15%
+    description: |-
+      This example lists all promotion events where any discount is greater than 15%.
+    query: |-
+      db.stores.aggregate([
+        {
+          $unwind: "$promotionEvents"
+        },
+        {
+          $unwind: "$promotionEvents.discounts"
+        },
+        {
+          $match: {
+            "promotionEvents.discounts.discountPercentage": { $gt: 15 }
+          }
+        },
+        {
+          $group: {
+            _id: "$promotionEvents.eventName",
+            discounts: { $push: "$promotionEvents.discounts" }
+          }
+        }
+      ])
+    output:
+      value: |-
+        [
+          {
+            [
+              { categoryName: 'Basketball Gear', discountPercentage: 23 },
+              { categoryName: 'Wool Carpets', discountPercentage: 22 },
+              {
+                categoryName: 'Portable Bluetooth Speakers',
+                discountPercentage: 24
+              }
+            ]
+          }
+        ]
+related: []

--- a/reference/command/aggregation/count.yml
+++ b/reference/command/aggregation/count.yml
@@ -2,98 +2,52 @@ type: command
 category: aggregation
 name: count
 description: |-
-  The `count` command is used to count the number of documents in a collection that match specific criteria.
+  Count command is used to count the number of documents in a collection that match a specified query.
 summary: |-
-  This command is useful for obtaining quick statistics about the data stored in your collections, such as the number of documents that meet certain criteria.
+  The `count` command is used to count the number of documents in a collection that match a specified query. This command is useful for obtaining quick statistics about the data stored in your collections, such as the number of documents that meet certain criteria.
 syntax: |-
-  db.collection.count(
-    <query>,
-    <options>
-  );
+  db.collection.count(query, options)
 parameters:
-  - name: query
-    required: true
-    description: |-
-      A document specifying the selection criteria using query operators.
-  - name: options
-    required: false
-    description: |-
-      A document specifying options including, but not limited to `limit` and `skip`.
+- name: query
+  required: true
+  description: |-
+    A document specifying the selection criteria using query operators.
+- name: options
+  required: false
+  description: |-
+    Optional. A document specifying options, such as `limit` and `skip`.
 examples:
-  sample: |-
-    [
-      {
-        "_id": "00000000-0000-0000-0000-000000003001",
-        "name": "Proseware, Inc. | Home Entertainment Hub - East Linwoodbury",
-        "promotionEvents": [
-          {
-            "eventName": "Unbeatable Bargain Bash"
-          },
-          {
-            "eventName": "Steal of a Deal Days"
-          }
-        ]
-      },
-      {
-        "_id": "00000000-0000-0000-0000-000000003002",
-        "name": "Fabrikam, Inc. | Home Accessory Outlet - West Adele",
-        "promotionEvents": [
-          {
-            "eventName": "Incredible Discount Days"
-          },
-          {
-            "eventName": "Steal of a Deal Days"
-          }
-        ],
-        "location": {
-          "lat": -89.2384,
-          "lon": -46.4012
-        }
-      },
-      {
-        "_id": "00000000-0000-0000-0000-000000003003",
-        "name": "Wide World Importers | Fitness Equipment Outlet - Reillyborough",
-        "promotionEvents": [
-          {
-            "eventName": "Incredible Discount Days"
-          }
-        ],
-        "location": {
-          "lat": -2.4111,
-          "lon": 72.1041
-        }
-      }
-    ]
   items:
-    - title: Counting all documents in a collection
-      explanation: |-
-        Use the `count` command with an empty document to count **all** documents in a collection.
-      description: |-
-        In this example, all documents in the `stores` collection are counted.
-      query: |-
-        db.stores.count({ "_id": "00000000-0000-0000-0000-000000003002" })
-      output:
-        value: |-
-          1
-    - title: Counting documents that match nested criteria
-      explanation: |-
-        The `query` parameter supports nested parameters.
-      description: |-
-        In this example, the command counts documents that match the string value `"Incredible Discount Days"` for the `promotionEvents.eventName` field.
-      query: |-
-        db.stores.count({ "promotionEvents.eventName": "Incredible Discount Days" })
-      output:
-        value: |-
-          2
-    - title: Counting documents that match multiple criteria
-      explanation: |-
-        The `query` parameter also supports multiple parameters.
-      description: |-
-        In this example, the `locationLatitude` and `locationLongitude` parameters are used to count documents that match on these specific values.
-      query: |-
-        db.stores.count({ "location.lat": -2.4111, "location.lon": 72.1041 })
-      output:
-        value: |-
-          1
-related:
-  - reference: /operator/evaluation-query/regex
+  - title: Counting all documents in a collection
+    description: |-
+      To count all documents in the `stores` collection:
+    query: |-
+      db.stores.count({})
+    output:
+      value: |-
+        60570
+  - title: Counting documents with specific criteria
+    description: |-
+      To count the number of stores with a specific `_id` store ID:
+    query: |-
+      db.stores.count({ "_id": "e5767a9f-cd95-439c-9ec4-7ddc13d22926" })
+    output:
+      value: |-
+        1
+  - title: Counting documents with nested criteria
+    description: |-
+      To count the number of stores that have a specific promotion event:
+    query: |-
+      db.stores.count({ "promotionEvents.eventName": "Incredible Discount Days" })
+    output:
+      value: |-
+        2156
+  - title: Counting documents with multiple criteria
+    description: |-
+      To count the number of stores located at a specific latitude and longitude:
+    query: |-
+      db.stores.count({ "location.lat": -2.4111, "location.lon": 72.1041 })
+    output:
+      value: |-
+        1
+related: []

--- a/reference/command/aggregation/distinct.yml
+++ b/reference/command/aggregation/distinct.yml
@@ -1,0 +1,71 @@
+type: command
+category: aggregation
+name: distinct
+description: |-
+  The distinct command is used to find the unique values for a specified field across a single collection.
+summary: |-
+  The `distinct` command is used to find the unique values for a specified field across a single collection. This command is useful when you need to identify the set of distinct values for a field without retrieving all the documents or when you need to perform operations like filtering or grouping based on unique values.
+syntax: |-
+  db.collection.distinct(field, query, options)
+parameters:
+- name: field
+  required: true
+  description: |-
+    The field that receives the returned distinct values.
+- name: query
+  required: false
+  description: |-
+    Optional. A query that specifies the documents from which to retrieve the distinct values.
+- name: options
+  required: false
+  description: |-
+    Optional. Other options for the command.
+examples:
+  items:
+  - title: Find distinct categories in sales
+    description: |-
+      To find the distinct `categoryName` in the `salesByCategory` array:
+    query: |-
+      db.stores.distinct("sales.salesByCategory.categoryName")
+    output:
+      value: |-
+        [
+          {
+            _id: 'Discount Derby',
+            discounts: [
+              { categoryName: 'Bath Sheets', discountPercentage: 25 },
+              { categoryName: 'Tablecloths', discountPercentage: 25 },
+              { categoryName: 'Drapes', discountPercentage: 25 }
+            ]
+          }
+        ]
+  - title: Find distinct event names in promotion events
+    description: |-
+      To find the distinct `eventName` in the `promotionEvents` array:
+    query: |-
+      db.stores.distinct("promotionEvents.eventName")
+    output:
+      value: |-
+        [
+        {
+            _id: 'Super Saver Celebration',
+            discounts: [
+              { categoryName: 'Face Towels', discountPercentage: 25 },
+              { categoryName: 'Printer Ribbons', discountPercentage: 25 },
+              { categoryName: 'Chromebooks', discountPercentage: 25 }
+            ]
+            }
+        ]
+  - title: Find distinct discount percentages for a specific event
+    description: |-
+      To find the distinct `discountPercentage` in the `discounts` array for the "Summer Sale" event:
+    query: |-
+      db.stores.distinct("promotionEvents.discounts.discountPercentage", { "promotionEvents.eventName": "Incredible Discount Days" })
+    output:
+      value: |-
+        [
+           6, 17, 22, 25,  9, 15, 14,
+           7, 12, 19, 24,  5, 20, 10,
+          23, 16, 18, 21, 13, 11,  8
+        ]
+related: []


### PR DESCRIPTION
This pull request adds new reference YAML documentation for `aggregation` `commands`.

| New file | Original source |
| :--- | :--- |
| `/reference/command/aggregation/aggregate.yml` | <https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore/commands/aggregation/aggregate> |
| `/reference/command/aggregation/count.yml` | <https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore/commands/aggregation/count> |
| `/reference/command/aggregation/distinct.yml` | <https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore/commands/aggregation/distinct> |

> [!NOTE]
> These commands are generated from existing documentation on Microsoft Learn.

