### PR TITLE
Publish deb13 apt packages

### DIFF
--- a/.github/scripts/download_packages.sh
+++ b/.github/scripts/download_packages.sh
@@ -27,7 +27,8 @@ GOT_RPM=0
 DEB_POOL="out/deb/pool/${COMPONENTS}"
 # Debian/Ubuntu pools
 DEB_POOL_DEB11="out/deb/pool/deb11"
-DEB_POOL_DEB12="out/deb/pool/deb12" 
+DEB_POOL_DEB12="out/deb/pool/deb12"
+DEB_POOL_DEB13="out/deb/pool/deb13"
 DEB_POOL_UBUNTU22="out/deb/pool/ubuntu22"
 DEB_POOL_UBUNTU24="out/deb/pool/ubuntu24"
 # RPM pools
@@ -39,12 +40,14 @@ DEB_DISTS="dists/${SUITE}"
 DEB_DISTS_COMPONENTS_AMD64="${DEB_DISTS}/${COMPONENTS}/binary-amd64"
 DEB_DISTS_DEB11_AMD64="${DEB_DISTS}/deb11/binary-amd64"
 DEB_DISTS_DEB12_AMD64="${DEB_DISTS}/deb12/binary-amd64"
+DEB_DISTS_DEB13_AMD64="${DEB_DISTS}/deb13/binary-amd64"
 DEB_DISTS_UBUNTU22_AMD64="${DEB_DISTS}/ubuntu22/binary-amd64"
 DEB_DISTS_UBUNTU24_AMD64="${DEB_DISTS}/ubuntu24/binary-amd64"
 # ARM64 directories
 DEB_DISTS_COMPONENTS_ARM64="${DEB_DISTS}/${COMPONENTS}/binary-arm64"
 DEB_DISTS_DEB11_ARM64="${DEB_DISTS}/deb11/binary-arm64"
 DEB_DISTS_DEB12_ARM64="${DEB_DISTS}/deb12/binary-arm64"
+DEB_DISTS_DEB13_ARM64="${DEB_DISTS}/deb13/binary-arm64"
 DEB_DISTS_UBUNTU22_ARM64="${DEB_DISTS}/ubuntu22/binary-arm64"
 DEB_DISTS_UBUNTU24_ARM64="${DEB_DISTS}/ubuntu24/binary-arm64"
 GPG_TTY=""
@@ -54,7 +57,7 @@ generate_hashes() {
   HASH_TYPE="$1"
   HASH_COMMAND="$2"
   echo "${HASH_TYPE}:"
-  for component in ${COMPONENTS} deb11 deb12 ubuntu22 ubuntu24; do
+  for component in ${COMPONENTS} deb11 deb12 deb13 ubuntu22 ubuntu24; do
     if [ -d "$component" ]; then
       find "$component" -type f | while read -r file
       do
@@ -116,6 +119,12 @@ for asset in data.get('assets', []):
         clean_name=$(echo "$filename" | sed 's/^deb12-//')
         cp "out/packages/$filename" "$DEB_POOL_DEB12/$clean_name"
         sign_deb_package "$DEB_POOL_DEB12/$clean_name"
+      elif [[ "$filename" =~ ^deb13-postgresql-[0-9]+-documentdb.*\.deb$ ]]; then
+        GOT_DEB=1
+        mkdir -p "$DEB_POOL_DEB13"
+        clean_name=$(echo "$filename" | sed 's/^deb13-//')
+        cp "out/packages/$filename" "$DEB_POOL_DEB13/$clean_name"
+        sign_deb_package "$DEB_POOL_DEB13/$clean_name"
       elif [[ "$filename" =~ ^ubuntu22\.04-postgresql-[0-9]+-documentdb.*\.deb$ ]]; then
         GOT_DEB=1
         mkdir -p "$DEB_POOL_UBUNTU22"
@@ -209,6 +218,13 @@ if [ "$GOT_DEB" = "1" ]; then
     dpkg-scanpackages --arch arm64 pool/deb12/ > "${DEB_DISTS_DEB12_ARM64}/Packages"
     gzip -k -f "${DEB_DISTS_DEB12_AMD64}/Packages" "${DEB_DISTS_DEB12_ARM64}/Packages"
   fi
+
+  if [ -d "pool/deb13" ] && [ "$(ls -A pool/deb13/*.deb 2>/dev/null)" ]; then
+    mkdir -p "${DEB_DISTS_DEB13_AMD64}" "${DEB_DISTS_DEB13_ARM64}"
+    dpkg-scanpackages --arch amd64 pool/deb13/ > "${DEB_DISTS_DEB13_AMD64}/Packages"
+    dpkg-scanpackages --arch arm64 pool/deb13/ > "${DEB_DISTS_DEB13_ARM64}/Packages"
+    gzip -k -f "${DEB_DISTS_DEB13_AMD64}/Packages" "${DEB_DISTS_DEB13_ARM64}/Packages"
+  fi
   
   if [ -d "pool/ubuntu22" ] && [ "$(ls -A pool/ubuntu22/*.deb 2>/dev/null)" ]; then
     mkdir -p "${DEB_DISTS_UBUNTU22_AMD64}" "${DEB_DISTS_UBUNTU22_ARM64}"
@@ -253,6 +269,21 @@ if [ "$GOT_DEB" = "1" ]; then
     dpkg-scanpackages --arch arm64 pool/deb12/ > "${DEB_DISTS_DEB12_ARM64}/Packages"
     gzip -k -f "${DEB_DISTS_DEB12_ARM64}/Packages"
   fi
+
+  # Create deb13 component (Debian 13 Trixie)
+  if [ -d "pool/deb13" ] && [ "$(ls -A pool/deb13/*.deb 2>/dev/null)" ]; then
+    # AMD64 packages
+    mkdir -p "${DEB_DISTS_DEB13_AMD64}"
+    echo "Scanning Debian 13 AMD64 packages for deb13 component"
+    dpkg-scanpackages --arch amd64 pool/deb13/ > "${DEB_DISTS_DEB13_AMD64}/Packages"
+    gzip -k -f "${DEB_DISTS_DEB13_AMD64}/Packages"
+
+    # ARM64 packages
+    mkdir -p "${DEB_DISTS_DEB13_ARM64}"
+    echo "Scanning Debian 13 ARM64 packages for deb13 component"
+    dpkg-scanpackages --arch arm64 pool/deb13/ > "${DEB_DISTS_DEB13_ARM64}/Packages"
+    gzip -k -f "${DEB_DISTS_DEB13_ARM64}/Packages"
+  fi
   
   # Create ubuntu22 component (Ubuntu 22.04 Jammy)
   if [ -d "pool/ubuntu22" ] && [ "$(ls -A pool/ubuntu22/*.deb 2>/dev/null)" ]; then
@@ -292,14 +323,15 @@ if [ "$GOT_DEB" = "1" ]; then
   [ -d "${COMPONENTS}/binary-amd64" ] && AVAILABLE_COMPONENTS="${AVAILABLE_COMPONENTS} ${COMPONENTS}"
   [ -d "deb11/binary-amd64" ] && AVAILABLE_COMPONENTS="${AVAILABLE_COMPONENTS} deb11"
   [ -d "deb12/binary-amd64" ] && AVAILABLE_COMPONENTS="${AVAILABLE_COMPONENTS} deb12"
+  [ -d "deb13/binary-amd64" ] && AVAILABLE_COMPONENTS="${AVAILABLE_COMPONENTS} deb13"
   [ -d "ubuntu22/binary-amd64" ] && AVAILABLE_COMPONENTS="${AVAILABLE_COMPONENTS} ubuntu22"
   [ -d "ubuntu24/binary-amd64" ] && AVAILABLE_COMPONENTS="${AVAILABLE_COMPONENTS} ubuntu24"
   AVAILABLE_COMPONENTS=$(echo $AVAILABLE_COMPONENTS | sed 's/^ *//')
   
   # Determine available architectures
   AVAILABLE_ARCHITECTURES=""
-  [ -d "${COMPONENTS}/binary-amd64" ] || [ -d "deb11/binary-amd64" ] || [ -d "deb12/binary-amd64" ] || [ -d "ubuntu22/binary-amd64" ] || [ -d "ubuntu24/binary-amd64" ] && AVAILABLE_ARCHITECTURES="${AVAILABLE_ARCHITECTURES} amd64"
-  [ -d "${COMPONENTS}/binary-arm64" ] || [ -d "deb11/binary-arm64" ] || [ -d "deb12/binary-arm64" ] || [ -d "ubuntu22/binary-arm64" ] || [ -d "ubuntu24/binary-arm64" ] && AVAILABLE_ARCHITECTURES="${AVAILABLE_ARCHITECTURES} arm64"
+  [ -d "${COMPONENTS}/binary-amd64" ] || [ -d "deb11/binary-amd64" ] || [ -d "deb12/binary-amd64" ] || [ -d "deb13/binary-amd64" ] || [ -d "ubuntu22/binary-amd64" ] || [ -d "ubuntu24/binary-amd64" ] && AVAILABLE_ARCHITECTURES="${AVAILABLE_ARCHITECTURES} amd64"
+  [ -d "${COMPONENTS}/binary-arm64" ] || [ -d "deb11/binary-arm64" ] || [ -d "deb12/binary-arm64" ] || [ -d "deb13/binary-arm64" ] || [ -d "ubuntu22/binary-arm64" ] || [ -d "ubuntu24/binary-arm64" ] && AVAILABLE_ARCHITECTURES="${AVAILABLE_ARCHITECTURES} arm64"
   AVAILABLE_ARCHITECTURES=$(echo $AVAILABLE_ARCHITECTURES | sed 's/^ *//')
   
   {

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -79,6 +79,48 @@ jobs:
         run: npm run build
       - name: Download DocumentDB packages from latest release
         run: .github/scripts/download_packages.sh
+      - name: Verify generated package components
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          release_info = Path("out/packages/release-info.json")
+          if not release_info.exists():
+              raise SystemExit("release-info.json was not generated")
+
+          data = json.loads(release_info.read_text())
+          assets = [asset["name"] for asset in data.get("assets", [])]
+          components = ("deb11", "deb12", "deb13", "ubuntu22", "ubuntu24")
+
+          for component in components:
+              has_assets = any(
+                  name.endswith(".deb")
+                  and (
+                      name.startswith(f"{component}-")
+                      or name.startswith(f"{component}.04-")
+                  )
+                  for name in assets
+              )
+              if not has_assets:
+                  continue
+
+              for arch in ("amd64", "arm64"):
+                  packages = Path(f"out/deb/dists/stable/{component}/binary-{arch}/Packages")
+                  packages_gz = Path(f"out/deb/dists/stable/{component}/binary-{arch}/Packages.gz")
+                  if not packages.exists() or not packages_gz.exists():
+                      raise SystemExit(
+                          f"Missing APT metadata for {component} {arch}: "
+                          f"{packages} / {packages_gz}"
+                      )
+
+          release_file = Path("out/deb/dists/stable/Release")
+          if release_file.exists() and any(name.startswith("deb13-") and name.endswith(".deb") for name in assets):
+              release_text = release_file.read_text()
+              if "deb13" not in release_text:
+                  raise SystemExit("deb13 assets exist but deb13 is missing from the APT Release file")
+          PY
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/PACKAGE-INSTALL.md
+++ b/PACKAGE-INSTALL.md
@@ -7,13 +7,14 @@ Verified installation commands for the DocumentDB PostgreSQL extension.
 - Repository-backed installs were exercised in Docker on Ubuntu 22.04, Ubuntu 24.04, Debian 11, Debian 12, Rocky Linux 8, and Rocky Linux 9.
 - Both `amd64`/`x86_64` and `arm64`/`aarch64` variants were checked.
 - PostgreSQL package variants `16`, `17`, and `18` were resolved successfully for the supported repository-backed combinations, with one exception: Debian 11 currently resolves PostgreSQL `16` and `17` only.
-- Debian 13 `.deb` assets are published on GitHub Releases, but the APT repository does **not** currently publish a `deb13` component, so Debian 13 should use direct downloads for now.
+- Debian 13 `.deb` assets are published on GitHub Releases, and the APT repository now publishes a `deb13` component for repository-backed installs.
 
 ## Supported PostgreSQL Versions
 
 - Ubuntu 22.04 / 24.04: 16, 17, 18
 - Debian 11: 16, 17
 - Debian 12: 16, 17, 18
+- Debian 13: 16, 17, 18
 - RHEL-family 8 / 9: 16, 17, 18
 
 ## Repository-backed package installs
@@ -68,6 +69,19 @@ curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearm
 echo "deb [signed-by=/usr/share/keyrings/postgresql.gpg] https://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null && \
 curl -fsSL https://documentdb.io/documentdb-archive-keyring.gpg | sudo gpg --dearmor --yes -o /usr/share/keyrings/documentdb-archive-keyring.gpg && \
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/documentdb-archive-keyring.gpg] https://documentdb.io/deb stable deb12" | sudo tee /etc/apt/sources.list.d/documentdb.list >/dev/null && \
+sudo apt update && \
+sudo apt install -y postgresql-16-documentdb
+```
+
+### Debian 13 (Trixie)
+
+```bash
+sudo apt update && \
+sudo apt install -y curl ca-certificates gnupg && \
+curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor --yes -o /usr/share/keyrings/postgresql.gpg && \
+echo "deb [signed-by=/usr/share/keyrings/postgresql.gpg] https://apt.postgresql.org/pub/repos/apt trixie-pgdg main" | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null && \
+curl -fsSL https://documentdb.io/documentdb-archive-keyring.gpg | sudo gpg --dearmor --yes -o /usr/share/keyrings/documentdb-archive-keyring.gpg && \
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/documentdb-archive-keyring.gpg] https://documentdb.io/deb stable deb13" | sudo tee /etc/apt/sources.list.d/documentdb.list >/dev/null && \
 sudo apt update && \
 sudo apt install -y postgresql-16-documentdb
 ```
@@ -158,7 +172,6 @@ rhel9-postgresql18-documentdb-0.109.0-1.el9.x86_64.rpm
 
 ## Notes
 
-- The APT repository currently publishes components for `ubuntu22`, `ubuntu24`, `deb11`, and `deb12`.
-- Debian 13 assets exist on GitHub Releases, but the APT repository component is not published yet.
+- The APT repository currently publishes components for `ubuntu22`, `ubuntu24`, `deb11`, `deb12`, and `deb13`.
 - Debian 11 PostgreSQL 18 assets exist, but the upstream Bullseye PostGIS dependency is not currently installable from PGDG.
 - The RPM flow depends on EPEL plus PostgreSQL's upstream RPM repository because DocumentDB depends on PostgreSQL, `pg_cron`, `pgvector`, PostGIS, and `rum`.

--- a/app/lib/packageInstall.ts
+++ b/app/lib/packageInstall.ts
@@ -1,4 +1,4 @@
-export type AptDistro = "ubuntu22" | "ubuntu24" | "deb11" | "deb12";
+export type AptDistro = "ubuntu22" | "ubuntu24" | "deb11" | "deb12" | "deb13";
 export type RpmDistro = "rhel8" | "rhel9";
 export type AptArch = "amd64" | "arm64";
 export type RpmArch = "x86_64" | "aarch64";
@@ -10,6 +10,7 @@ export const aptTargetLabels: Record<AptDistro, string> = {
   ubuntu24: "Ubuntu 24.04 (Noble)",
   deb11: "Debian 11 (Bullseye)",
   deb12: "Debian 12 (Bookworm)",
+  deb13: "Debian 13 (Trixie)",
 };
 
 export const rpmTargetLabels: Record<RpmDistro, string> = {
@@ -22,6 +23,7 @@ export const aptTargetPgVersions: Record<AptDistro, AptPgVersion[]> = {
   ubuntu24: ["16", "17", "18"],
   deb11: ["16", "17"],
   deb12: ["16", "17", "18"],
+  deb13: ["16", "17", "18"],
 };
 
 const aptPgdgSuites: Record<AptDistro, string> = {
@@ -29,6 +31,7 @@ const aptPgdgSuites: Record<AptDistro, string> = {
   ubuntu24: "noble",
   deb11: "bullseye",
   deb12: "bookworm",
+  deb13: "trixie",
 };
 
 const rpmMajorVersions: Record<RpmDistro, "8" | "9"> = {

--- a/app/packages/page.tsx
+++ b/app/packages/page.tsx
@@ -278,8 +278,8 @@ export default function PackagesPage() {
               </p>
               {packageFamily === "apt" ? (
                 <p className="mt-2 text-sm text-amber-300">
-                  Debian 13 is now available in the repository-backed APT flow. Debian 11
-                  currently supports PostgreSQL 16 and 17 in the repository-backed flow.
+                  Debian 13 is now supported in the APT repository-backed install flow. Debian
+                  11 currently supports only PostgreSQL 16 and 17.
                 </p>
               ) : null}
               <div className="mt-4">

--- a/app/packages/page.tsx
+++ b/app/packages/page.tsx
@@ -278,8 +278,7 @@ export default function PackagesPage() {
               </p>
               {packageFamily === "apt" ? (
                 <p className="mt-2 text-sm text-amber-300">
-                  Debian 13 packages are currently available from GitHub Releases as direct
-                  downloads while the APT repository component is being published. Debian 11
+                  Debian 13 is now available in the repository-backed APT flow. Debian 11
                   currently supports PostgreSQL 16 and 17 in the repository-backed flow.
                 </p>
               ) : null}
@@ -314,7 +313,7 @@ export default function PackagesPage() {
                 <tbody className="text-gray-300">
                   <tr className="border-b border-neutral-800">
                     <td className="px-3 py-3 font-semibold text-blue-300">APT</td>
-                    <td className="px-3 py-3">Ubuntu 22.04/24.04, Debian 11/12</td>
+                    <td className="px-3 py-3">Ubuntu 22.04/24.04, Debian 11/12/13</td>
                     <td className="px-3 py-3">amd64, arm64</td>
                     <td className="px-3 py-3">16, 17, 18 (Debian 11: 16, 17)</td>
                     <td className="px-3 py-3">
@@ -339,8 +338,8 @@ export default function PackagesPage() {
                 target instead of scanning all combinations manually.
               </p>
               <p className="mt-2 text-xs text-gray-500">
-                Debian 13 packages are published as direct <code>.deb</code> assets on GitHub
-                Releases until the APT repository component is available.
+                Debian 13 packages are available in the <code>deb13</code> APT component and
+                remain downloadable as direct <code>.deb</code> assets from GitHub Releases.
               </p>
             </div>
           </details>

--- a/app/services/articleService.ts
+++ b/app/services/articleService.ts
@@ -49,7 +49,7 @@ Install DocumentDB on Linux hosts with apt/rpm packages.
 
 Use the [Package Finder](/packages) to generate the exact install command for your distro, architecture, and PostgreSQL version.
 
-> The repository-backed install commands currently cover Ubuntu 22.04/24.04, Debian 11/12, and RHEL-family 8/9 systems. Debian 13 packages are available as direct downloads from GitHub Releases while the APT repository component is being published. Debian 11 currently resolves PostgreSQL 16 and 17 in the repository-backed flow.
+> The repository-backed install commands currently cover Ubuntu 22.04/24.04, Debian 11/12/13, and RHEL-family 8/9 systems. Debian 11 currently resolves PostgreSQL 16 and 17 in the repository-backed flow.
 
 ## APT example
 


### PR DESCRIPTION
## Summary
- publish `deb13` assets into the generated APT repository during the Pages deployment
- verify the generated package metadata includes `deb13` when upstream release assets exist
- expose Debian 13 in the package finder and package-install docs

## Validation
- `bash -n .github/scripts/download_packages.sh`
- YAML parse for `.github/workflows/continuous-deployment.yml`
- `npm run lint && npm run build`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>