### PR TITLE
Fix 404 on blog navigation links to flat-export Next.js pages

### DIFF
--- a/blogs/_layouts/default.html
+++ b/blogs/_layouts/default.html
@@ -15,9 +15,9 @@
     {% endif %}
 
     {% assign home_href = site_root | append: '/' | replace: '//', '/' %}
-    {% assign docs_href = site_root | append: '/docs/' | replace: '//', '/' %}
-    {% assign packages_href = site_root | append: '/packages/' | replace: '//', '/' %}
-    {% assign operator_href = site_root | append: '/kubernetes-operator/' | replace: '//', '/' %}
+    {% assign docs_href = site_root | append: '/docs' | replace: '//', '/' %}
+    {% assign packages_href = site_root | append: '/packages' | replace: '//', '/' %}
+    {% assign operator_href = site_root | append: '/kubernetes-operator' | replace: '//', '/' %}
     {% assign logo_href = site_root | append: '/images/DocumentDB Logo - background removed.png' | replace: '//', '/' %}
     {% assign blogs_href = site.baseurl | append: '/' | replace: '//', '/' %}
 


### PR DESCRIPTION
## Problem

Navigation links from the blog (`/blogs/` and `/blogs/posts/...`) back to the K8s Operator, Docs, and Download pages return **404** in production.

Reproduction (live):
- https://documentdb.io/kubernetes-operator/ -> 404
- https://documentdb.io/kubernetes-operator -> works
- https://documentdb.io/docs/ -> 404
- https://documentdb.io/packages/ -> 404

## Root cause

`blogs/_layouts/default.html` builds the nav with trailing slashes:

```liquid
{% assign docs_href = site_root | append: '/docs/' ... %}
{% assign packages_href = site_root | append: '/packages/' ... %}
{% assign operator_href = site_root | append: '/kubernetes-operator/' ... %}
```

But the Next.js static export (`output: "export"`) emits flat HTML files at `out/docs.html`, `out/packages.html`, `out/kubernetes-operator.html` with no `{route}/index.html` counterpart. GitHub Pages serves those at `/docs`, `/packages`, `/kubernetes-operator` only; the trailing-slash variants look for `/{route}/index.html` and 404.

Every other internal link in the repo (Next.js pages, articles markdown, the `/blogs/` self-link, etc.) already uses the no-trailing-slash convention, so this layout was the sole offender.

## Fix

Drop the trailing slash from the three offending hrefs. `home_href` (`/`) and `blogs_href` (`/blogs/`) keep their slash because they resolve to real `index.html` files (`out/index.html`, `out/blogs/index.html`).

## Verification

Rebuilt the Jekyll blog with both deployment baseurls and confirmed the generated nav now points to existing files.

Local (`--baseurl /blogs`):
```
href="/"
href="/blogs/"
href="/docs"
href="/kubernetes-operator"
href="/packages"
```

CI deployment (`--baseurl /documentdb.github.io/blogs`):
```
href="/documentdb.github.io/"
href="/documentdb.github.io/blogs/"
href="/documentdb.github.io/docs"
href="/documentdb.github.io/kubernetes-operator"
href="/documentdb.github.io/packages"
```

All resolve to existing files in the `out/` artifact.

Verified with a wider audit that no other Jekyll templates, Next.js pages, or markdown content emit internal links with trailing slashes to flat-export routes.