### PR TITLE
Fix Linux package install guide and Package Finder

### DIFF
--- a/PACKAGE-INSTALL.md
+++ b/PACKAGE-INSTALL.md
@@ -1,13 +1,14 @@
 # DocumentDB Package Installation
 
-Verified installation commands for the DocumentDB PostgreSQL extension.
+Repository-backed installation commands for the DocumentDB PostgreSQL extension package.
 
-## What was validated
+## What is published
 
-- Repository-backed installs were exercised in Docker on Ubuntu 22.04, Ubuntu 24.04, Debian 11, Debian 12, Rocky Linux 8, and Rocky Linux 9.
-- Both `amd64`/`x86_64` and `arm64`/`aarch64` variants were checked.
-- PostgreSQL package variants `16`, `17`, and `18` were resolved successfully for the supported repository-backed combinations, with one exception: Debian 11 currently resolves PostgreSQL `16` and `17` only.
+- Repository-backed extension packages are published for Ubuntu 22.04, Ubuntu 24.04, Debian 11, Debian 12, Debian 13, RHEL-compatible 8, and RHEL-compatible 9 targets.
+- Both `amd64`/`x86_64` and `arm64`/`aarch64` variants are published.
+- PostgreSQL package variants `16`, `17`, and `18` are published for the supported repository-backed combinations, with one exception: Debian 11 currently resolves PostgreSQL `16` and `17` only.
 - Debian 13 `.deb` assets are published on GitHub Releases, and the APT repository now publishes a `deb13` component for repository-backed installs.
+- The published package repository installs the PostgreSQL extension package. It does not currently publish a gateway package, setup helper, or systemd service.
 
 ## Supported PostgreSQL Versions
 
@@ -15,11 +16,11 @@ Verified installation commands for the DocumentDB PostgreSQL extension.
 - Debian 11: 16, 17
 - Debian 12: 16, 17, 18
 - Debian 13: 16, 17, 18
-- RHEL-family 8 / 9: 16, 17, 18
+- RHEL-compatible 8 / 9: 16, 17, 18
 
 ## Repository-backed package installs
 
-These commands install the required PostgreSQL upstream repositories first, then add the DocumentDB package repository, and finally install the DocumentDB extension package.
+These commands install the required PostgreSQL upstream repositories first, then add the DocumentDB package repository, and finally install the DocumentDB PostgreSQL extension package.
 
 ### Ubuntu 22.04 (Jammy)
 
@@ -86,7 +87,7 @@ sudo apt update && \
 sudo apt install -y postgresql-16-documentdb
 ```
 
-### RHEL / Rocky / AlmaLinux / CentOS Stream 8
+### RHEL-compatible 8
 
 ```bash
 sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
@@ -107,7 +108,7 @@ printf '%s\n' \
 sudo dnf install -y postgresql16-documentdb
 ```
 
-### RHEL / Rocky / AlmaLinux / CentOS Stream 9
+### RHEL-compatible 9
 
 ```bash
 sudo dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
@@ -174,4 +175,4 @@ rhel9-postgresql18-documentdb-0.110.0-1.el9.x86_64.rpm
 
 - The APT repository currently publishes components for `ubuntu22`, `ubuntu24`, `deb11`, `deb12`, and `deb13`.
 - Debian 11 PostgreSQL 18 assets exist, but the upstream Bullseye PostGIS dependency is not currently installable from PGDG.
-- The RPM flow depends on EPEL plus PostgreSQL's upstream RPM repository because DocumentDB depends on PostgreSQL, `pg_cron`, `pgvector`, PostGIS, and `rum`.
+- The RPM flow depends on EPEL plus PostgreSQL's upstream RPM repository because DocumentDB depends on PostgreSQL, `pg_cron`, `pgvector`, PostGIS, and `rum` for PostgreSQL 16/17.

--- a/PACKAGE-INSTALL.md
+++ b/PACKAGE-INSTALL.md
@@ -8,7 +8,7 @@ Repository-backed installation commands for the DocumentDB PostgreSQL extension 
 - Both `amd64`/`x86_64` and `arm64`/`aarch64` variants are published.
 - PostgreSQL package variants `16`, `17`, and `18` are published for the supported repository-backed combinations, with one exception: Debian 11 currently resolves PostgreSQL `16` and `17` only.
 - Debian 13 `.deb` assets are published on GitHub Releases, and the APT repository now publishes a `deb13` component for repository-backed installs.
-- The published package repository installs the PostgreSQL extension package. It does not currently publish a gateway package, setup helper, or systemd service.
+- The published package repository installs the PostgreSQL extension package. It does not currently publish a gateway package, setup helper, or systemd service in either the repository-backed install flow or GitHub Releases.
 
 ## Supported PostgreSQL Versions
 
@@ -156,9 +156,62 @@ dnf --showduplicates list postgresql16-documentdb
 sudo dnf install postgresql16-documentdb-<VERSION>
 ```
 
+## From package install to a local `mongosh` endpoint
+
+The repository-backed install gives you the PostgreSQL extension package. To expose a local MongoDB-compatible endpoint on the same host, run PostgreSQL and the gateway from the source repository against the packaged extension files.
+
+### Prerequisites
+
+- `git`
+- A Rust toolchain (`cargo` and `rustc`)
+- `mongosh`
+
+Example package-manager installs:
+
+```bash
+# Debian / Ubuntu
+sudo apt install -y git rustc cargo
+
+# RHEL-compatible
+sudo dnf install -y git rust cargo
+```
+
+### Example host flow
+
+Replace `<PG_MAJOR>` with the PostgreSQL major version you installed from the package repository, such as `16`, `17`, or `18`.
+
+```bash
+git clone https://github.com/documentdb/documentdb.git
+cd documentdb
+
+export PG_VERSION_USED=<PG_MAJOR>
+
+./scripts/start_oss_server.sh -c -u <YOUR_USERNAME> -a <YOUR_PASSWORD>
+
+./scripts/build_and_start_gateway.sh -c \
+  -u <YOUR_USERNAME> \
+  -p <YOUR_PASSWORD> \
+  -P 9712
+```
+
+- `./scripts/start_oss_server.sh -c` initializes a fresh local PostgreSQL data directory under `~/.documentdb/data`.
+- `./scripts/build_and_start_gateway.sh -c` forces a clean gateway rebuild; after the first successful build, you can omit `-c` on later restarts.
+- Keep the gateway command running in the foreground. It listens on port `10260` and connects to PostgreSQL on port `9712`.
+
+Then connect with `mongosh`:
+
+```bash
+mongosh localhost:10260 \
+  -u <YOUR_USERNAME> \
+  -p <YOUR_PASSWORD> \
+  --authenticationMechanism SCRAM-SHA-256 \
+  --tls \
+  --tlsAllowInvalidCertificates
+```
+
 ## Direct downloads
 
-GitHub Releases contains `.deb` and `.rpm` assets for every published combination, including Debian 13 release assets.
+GitHub Releases contains `.deb` and `.rpm` extension assets for every published combination, including Debian 13 release assets. It does not currently publish a gateway package.
 
 Examples:
 

--- a/PACKAGE-INSTALL.md
+++ b/PACKAGE-INSTALL.md
@@ -22,6 +22,10 @@ Repository-backed installation commands for the DocumentDB PostgreSQL extension 
 
 These commands install the required PostgreSQL upstream repositories first, then add the DocumentDB package repository, and finally install the DocumentDB PostgreSQL extension package.
 
+> These commands assume a regular Linux host where you use `sudo`. If you are testing in a clean container that already runs as `root`, omit `sudo` from the package-install commands.
+>
+> On Debian and Ubuntu in a clean container, also run `export DEBIAN_FRONTEND=noninteractive` in the shell before the APT commands. Without it, `tzdata` (and a few other packages) prompt for input during `apt install` and the install hangs with no visible error.
+
 ### Ubuntu 22.04 (Jammy)
 
 ```bash
@@ -163,28 +167,59 @@ The repository-backed install gives you the PostgreSQL extension package. To exp
 ### Prerequisites
 
 - `git`
-- A Rust toolchain (`cargo` and `rustc`)
+- `curl`
+- Native build tools for Rust crates that link against OpenSSL
+- A current Rust toolchain via `rustup`
 - `mongosh`
+
+> Run the PostgreSQL and gateway steps from an unprivileged user account, not `root`. PostgreSQL will not initialize as `root`.
+>
+> If you are following these steps in a clean container that starts as `root`, finish the package-install commands as `root`, then switch to an unprivileged account such as `postgres` before you start PostgreSQL or the gateway.
+
+```bash
+# from a root shell inside the container
+su - postgres
+```
 
 Example package-manager installs:
 
 ```bash
 # Debian / Ubuntu
-sudo apt install -y git rustc cargo
+sudo apt install -y git curl build-essential pkg-config libssl-dev
 
 # RHEL-compatible
-sudo dnf install -y git rust cargo
+sudo dnf install -y git curl gcc gcc-c++ make pkgconf-pkg-config openssl-devel
 ```
+
+Install a current Rust toolchain with `rustup`, then load it into your shell:
+
+```bash
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+. "$HOME/.cargo/env"
+```
+
+In a clean container that starts as `root`, install the system packages above and install `mongosh` while you are still `root`. Then switch to the unprivileged user and run the `rustup` commands plus the remaining gateway steps from that user's shell.
 
 ### Example host flow
 
 Replace `<PG_MAJOR>` with the PostgreSQL major version you installed from the package repository, such as `16`, `17`, or `18`.
+
+If you do not already have `mongosh`, install it with the official MongoDB shell instructions for your distro before continuing:
+
+- https://www.mongodb.com/docs/mongodb-shell/install/
 
 ```bash
 git clone https://github.com/documentdb/documentdb.git
 cd documentdb
 
 export PG_VERSION_USED=<PG_MAJOR>
+
+# Required in non-interactive shells (CI, `docker exec` without `-t`,
+# `docker exec -d`, `nohup`, background `&`). build_and_start_gateway.sh
+# calls `tput` for colored output and aborts under `set -u` / `set -e` if
+# TERM is unset or set to `dumb`. Skip this line in a normal interactive
+# terminal where TERM is already `xterm`, `xterm-256color`, etc.
+export TERM=xterm
 
 ./scripts/start_oss_server.sh -c -u <YOUR_USERNAME> -a <YOUR_PASSWORD>
 
@@ -197,6 +232,7 @@ export PG_VERSION_USED=<PG_MAJOR>
 - `./scripts/start_oss_server.sh -c` initializes a fresh local PostgreSQL data directory under `~/.documentdb/data`.
 - `./scripts/build_and_start_gateway.sh -c` forces a clean gateway rebuild; after the first successful build, you can omit `-c` on later restarts.
 - Keep the gateway command running in the foreground. It listens on port `10260` and connects to PostgreSQL on port `9712`.
+- The first gateway build downloads several hundred Rust crates and typically takes a few minutes before the gateway begins listening on port `10260`. Subsequent runs without `-c` are much faster.
 
 Then connect with `mongosh`:
 
@@ -229,3 +265,4 @@ rhel9-postgresql18-documentdb-0.110.0-1.el9.x86_64.rpm
 - The APT repository currently publishes components for `ubuntu22`, `ubuntu24`, `deb11`, `deb12`, and `deb13`.
 - Debian 11 PostgreSQL 18 assets exist, but the upstream Bullseye PostGIS dependency is not currently installable from PGDG.
 - The RPM flow depends on EPEL plus PostgreSQL's upstream RPM repository because DocumentDB depends on PostgreSQL, `pg_cron`, `pgvector`, PostGIS, and `rum` for PostgreSQL 16/17.
+- On Debian/Ubuntu, the distro-packaged `cargo` can be older than the current gateway workspace lockfile. `rustup` avoids that mismatch.

--- a/app/lib/packageInstall.ts
+++ b/app/lib/packageInstall.ts
@@ -14,8 +14,8 @@ export const aptTargetLabels: Record<AptDistro, string> = {
 };
 
 export const rpmTargetLabels: Record<RpmDistro, string> = {
-  rhel8: "RHEL 8 / Rocky 8 / AlmaLinux 8 / CentOS Stream 8",
-  rhel9: "RHEL 9 / Rocky 9 / AlmaLinux 9 / CentOS Stream 9",
+  rhel8: "RHEL-compatible 8 (tested on Rocky Linux 8)",
+  rhel9: "RHEL-compatible 9 (tested on Rocky Linux 9)",
 };
 
 export const aptTargetPgVersions: Record<AptDistro, AptPgVersion[]> = {
@@ -53,7 +53,7 @@ echo "deb [signed-by=/usr/share/keyrings/postgresql.gpg] https://apt.postgresql.
 curl -fsSL https://documentdb.io/documentdb-archive-keyring.gpg | sudo gpg --dearmor --yes -o /usr/share/keyrings/documentdb-archive-keyring.gpg && \\
 echo "deb [arch=${aptArch} signed-by=/usr/share/keyrings/documentdb-archive-keyring.gpg] https://documentdb.io/deb stable ${aptTarget}" | sudo tee /etc/apt/sources.list.d/documentdb.list >/dev/null && \\
 sudo apt update && \\
-sudo apt install -y postgresql-${aptPgVersion}-documentdb documentdb_gateway`;
+sudo apt install -y postgresql-${aptPgVersion}-documentdb`;
 }
 
 export function buildRpmInstallCommand(
@@ -78,5 +78,5 @@ printf '%s\\n' \\
   'enabled=1' \\
   'gpgcheck=1' \\
   'gpgkey=https://documentdb.io/documentdb-archive-keyring.gpg' | sudo tee /etc/yum.repos.d/documentdb.repo >/dev/null && \\
-sudo dnf install -y postgresql${rpmPgVersion}-documentdb documentdb-gateway`;
+sudo dnf install -y postgresql${rpmPgVersion}-documentdb`;
 }

--- a/app/packages/page.tsx
+++ b/app/packages/page.tsx
@@ -287,6 +287,15 @@ export default function PackagesPage() {
                 It installs the PostgreSQL extension package. The published package repository
                 does not currently include a gateway package, setup helper, or systemd service.
               </p>
+              {packageFamily === "apt" ? (
+                <p className="mt-2 text-sm text-gray-400">
+                  Running in a clean Debian/Ubuntu container as <code className="text-gray-300">root</code>?
+                  Run <code className="text-gray-300">export DEBIAN_FRONTEND=noninteractive</code> in the shell first
+                  (and omit <code className="text-gray-300">sudo</code> from the command above).
+                  Without it, <code className="text-gray-300">tzdata</code> prompts for input partway through
+                  and the install hangs with no visible error.
+                </p>
+              ) : null}
               <div className="mt-4 rounded-lg border border-neutral-700 bg-neutral-900/60 p-4">
                 <p className="mb-3 text-sm font-semibold text-white">
                   Need the MongoDB-compatible gateway?
@@ -294,7 +303,8 @@ export default function PackagesPage() {
                 <p className="mt-3 text-sm text-gray-400">
                   Use the Docker image for the fastest gateway-backed local setup. If you want a
                   package-backed host install that still works with <code className="text-gray-300">mongosh</code>,
-                  the Linux package guide includes the exact gateway follow-up commands.
+                  the Linux package guide includes the exact non-root gateway follow-up commands
+                  and host build prerequisites.
                 </p>
               </div>
               {packageFamily === "apt" ? (

--- a/app/packages/page.tsx
+++ b/app/packages/page.tsx
@@ -292,8 +292,9 @@ export default function PackagesPage() {
                   Need the MongoDB-compatible gateway?
                 </p>
                 <p className="mt-3 text-sm text-gray-400">
-                  Use the Docker image for the fastest gateway-backed local setup, or build and
-                  run the gateway from source against your PostgreSQL host.
+                  Use the Docker image for the fastest gateway-backed local setup. If you want a
+                  package-backed host install that still works with <code className="text-gray-300">mongosh</code>,
+                  the Linux package guide includes the exact gateway follow-up commands.
                 </p>
               </div>
               {packageFamily === "apt" ? (
@@ -475,8 +476,9 @@ export default function PackagesPage() {
             </h2>
             <p className="text-sm leading-6 text-gray-400">
               Docker starts a gateway-backed local endpoint on port 10260. Linux packages install
-              the PostgreSQL extension; use Docker or a source-built gateway when you need a
-              MongoDB-compatible endpoint.
+              the PostgreSQL extension; the Linux package guide adds the extra source-gateway
+              steps needed when you want a host install that still exposes a MongoDB-compatible
+              endpoint.
             </p>
           </div>
 

--- a/app/packages/page.tsx
+++ b/app/packages/page.tsx
@@ -79,17 +79,11 @@ export default function PackagesPage() {
   const rpmCommand = buildRpmInstallCommand(rpmTarget, rpmArch, rpmPgVersion);
   const selectedPackageNames =
     packageFamily === "apt"
-      ? `postgresql-${aptPgVersion}-documentdb + documentdb_gateway`
-      : `postgresql${rpmPgVersion}-documentdb + documentdb-gateway`;
+      ? `postgresql-${aptPgVersion}-documentdb`
+      : `postgresql${rpmPgVersion}-documentdb`;
   const selectedTargetText =
     packageFamily === "apt" ? aptTargetLabels[aptTarget] : rpmTargetLabels[rpmTarget];
   const selectedArchText = packageFamily === "apt" ? aptArch : rpmArch;
-  const selectedPgVersion = packageFamily === "apt" ? aptPgVersion : rpmPgVersion;
-  const setupCommand = `sudo documentdb-setup \\
-  --username <YOUR_USERNAME> \\
-  --password <YOUR_PASSWORD> \\
-  --pg-version ${selectedPgVersion} \\
-  --load-sample-data`;
 
   return (
     <div className="min-h-screen bg-neutral-900 py-12">
@@ -99,9 +93,9 @@ export default function PackagesPage() {
             Download DocumentDB
           </h1>
           <p className="mx-auto max-w-3xl text-lg text-gray-300">
-            Choose Docker for the fastest local setup, or Linux packages for managed host
-            installations. The generated package commands configure the PostgreSQL
-            dependency repositories and install the packages required by DocumentDB.
+            Choose Docker for the fastest local setup, or Linux packages for PostgreSQL
+            extension installs. The generated package commands configure the PostgreSQL
+            dependency repositories and install the DocumentDB extension package.
           </p>
           <div className="mt-4 flex flex-wrap justify-center gap-3 text-sm">
             <span className="rounded-full border border-green-500/30 bg-green-500/20 px-3 py-1 text-green-300">
@@ -287,21 +281,19 @@ export default function PackagesPage() {
                 The generated command adds the PostgreSQL upstream repositories that provide
                 PostgreSQL, <code className="text-gray-300">pg_cron</code>,{" "}
                 <code className="text-gray-300">pgvector</code>, PostGIS, and{" "}
-                <code className="text-gray-300">rum</code>.
+                <code className="text-gray-300">rum</code> for PostgreSQL 16/17.
               </p>
               <p className="mt-2 text-sm text-gray-400">
-                It also installs the PostgreSQL extension package plus the gateway package
-                required for MongoDB-compatible connections on port 10260.
+                It installs the PostgreSQL extension package. The published package repository
+                does not currently include a gateway package, setup helper, or systemd service.
               </p>
               <div className="mt-4 rounded-lg border border-neutral-700 bg-neutral-900/60 p-4">
                 <p className="mb-3 text-sm font-semibold text-white">
-                  Then initialize and start DocumentDB
+                  Need the MongoDB-compatible gateway?
                 </p>
-                <CommandSnippet command={setupCommand} label="Setup" />
                 <p className="mt-3 text-sm text-gray-400">
-                  Use <code className="text-gray-300">--skip-pg-init</code> and{" "}
-                  <code className="text-gray-300">--pg-port</code> if you want to attach
-                  DocumentDB to an existing PostgreSQL cluster instead of creating a new one.
+                  Use the Docker image for the fastest gateway-backed local setup, or build and
+                  run the gateway from source against your PostgreSQL host.
                 </p>
               </div>
               {packageFamily === "apt" ? (
@@ -351,7 +343,7 @@ export default function PackagesPage() {
                   <tr>
                     <td className="px-3 py-3 font-semibold text-red-300">RPM</td>
                     <td className="px-3 py-3">
-                      RHEL 8/9, Rocky, AlmaLinux, CentOS Stream
+                       RHEL-compatible 8/9 (tested on Rocky Linux)
                     </td>
                     <td className="px-3 py-3">x86_64, aarch64</td>
                     <td className="px-3 py-3">16, 17, 18</td>
@@ -463,19 +455,13 @@ export default function PackagesPage() {
               <div className="rounded-md border border-neutral-700 bg-black p-3">
                 <code className="text-xs text-green-400 sm:text-sm">
                   sudo apt update && apt search documentdb && apt-cache policy
-                  postgresql-16-documentdb documentdb_gateway
+                  postgresql-16-documentdb
                 </code>
               </div>
               <div className="rounded-md border border-neutral-700 bg-black p-3">
                 <code className="text-xs text-green-400 sm:text-sm">
                   sudo dnf clean all && dnf search documentdb && rpm -qi
-                  postgresql16-documentdb documentdb-gateway
-                </code>
-              </div>
-              <div className="rounded-md border border-neutral-700 bg-black p-3">
-                <code className="text-xs text-green-400 sm:text-sm">
-                  sudo systemctl status documentdb-gateway --no-pager && sudo journalctl -u
-                  documentdb-gateway --no-pager -n 20
+                  postgresql16-documentdb
                 </code>
               </div>
             </div>
@@ -488,9 +474,9 @@ export default function PackagesPage() {
               3. Connect and try it
             </h2>
             <p className="text-sm leading-6 text-gray-400">
-              After you run <code className="text-gray-300">documentdb-setup</code> and the
-              gateway is listening on port 10260, follow one of these guides to make your first
-              connection.
+              Docker starts a gateway-backed local endpoint on port 10260. Linux packages install
+              the PostgreSQL extension; use Docker or a source-built gateway when you need a
+              MongoDB-compatible endpoint.
             </p>
           </div>
 

--- a/app/services/articleService.ts
+++ b/app/services/articleService.ts
@@ -113,7 +113,7 @@ Install the DocumentDB PostgreSQL extension package on Debian, Ubuntu, or RHEL-c
 
 Use the [Package Finder](/packages) to generate the exact install command for your distro, architecture, and PostgreSQL version.
 
-> The generated command installs the PostgreSQL extension package and its PostgreSQL-side dependencies. The published package repository does not currently include a gateway package, setup helper, or systemd service.
+> The generated command installs the PostgreSQL extension package and its PostgreSQL-side dependencies. The published package repository and GitHub Releases do not currently include a gateway package, setup helper, or systemd service.
 >
 > The repository-backed install commands currently cover Ubuntu 22.04/24.04, Debian 11/12/13, and RHEL-compatible 8/9 systems. Debian 11 currently resolves PostgreSQL 16 and 17 in the repository-backed flow.
 
@@ -133,7 +133,7 @@ ${buildRpmInstallCommand('rhel9', 'x86_64', '16')}
 
 ## What the package installs
 
-The packages install the DocumentDB PostgreSQL extension files for the selected PostgreSQL major version. They do not start a MongoDB-compatible gateway endpoint on port \`10260\`.
+The packages install the DocumentDB PostgreSQL extension files for the selected PostgreSQL major version. They do not by themselves start a MongoDB-compatible gateway endpoint on port \`10260\`.
 
 Use the Docker quick start when you need the fastest local gateway-backed DocumentDB endpoint:
 
@@ -161,6 +161,61 @@ dnf info postgresql16-documentdb
 rpm -ql postgresql16-documentdb | grep -E 'documentdb.*\\.(control|sql|so)$' | head
 \`\`\`
 
+## Turn a package install into a local \`mongosh\` endpoint
+
+If you want to keep PostgreSQL on the host and still connect with \`mongosh\`, install the extension package first and then run the gateway from the source repository against that PostgreSQL instance.
+
+### Prerequisites for the host gateway step
+
+- [Git](https://git-scm.com/)
+- A Rust toolchain (\`cargo\` + \`rustc\`)
+- [mongosh](https://www.mongodb.com/docs/mongodb-shell/install/)
+
+Install Git and Rust with your distro package manager before continuing. Examples:
+
+\`\`\`bash
+# Debian / Ubuntu
+sudo apt install -y git rustc cargo
+
+# RHEL-compatible
+sudo dnf install -y git rust cargo
+\`\`\`
+
+### Host setup example
+
+Replace \`<PG_MAJOR>\` with the PostgreSQL major version you installed from the package repository, such as \`16\`, \`17\`, or \`18\`.
+
+\`\`\`bash
+git clone https://github.com/documentdb/documentdb.git
+cd documentdb
+
+export PG_VERSION_USED=<PG_MAJOR>
+
+./scripts/start_oss_server.sh -c -u <YOUR_USERNAME> -a <YOUR_PASSWORD>
+
+./scripts/build_and_start_gateway.sh -c \\
+  -u <YOUR_USERNAME> \\
+  -p <YOUR_PASSWORD> \\
+  -P 9712
+\`\`\`
+
+\`./scripts/start_oss_server.sh -c\` initializes a fresh local PostgreSQL data directory under \`~/.documentdb/data\`. \`./scripts/build_and_start_gateway.sh -c\` forces a clean gateway rebuild; after the first successful build, you can omit \`-c\` on later restarts.
+
+Keep the gateway command running in the foreground. It starts the MongoDB-compatible endpoint on port \`10260\` and connects it to PostgreSQL on port \`9712\`.
+
+Then connect with \`mongosh\`:
+
+\`\`\`bash
+mongosh localhost:10260 \\
+  -u <YOUR_USERNAME> \\
+  -p <YOUR_PASSWORD> \\
+  --authenticationMechanism SCRAM-SHA-256 \\
+  --tls \\
+  --tlsAllowInvalidCertificates
+\`\`\`
+
+Use this flow when you want a package-backed host install plus a local MongoDB-compatible endpoint. Use the Docker quick start instead when you want the shortest local setup path.
+
 ## Troubleshooting and debugging
 
 If something does not work on the first try:
@@ -168,6 +223,9 @@ If something does not work on the first try:
 - Confirm the extension package is installed: \`postgresql-<PG>-documentdb\` on APT or \`postgresql<PG>-documentdb\` on RPM
 - Re-run the Package Finder command for the exact distro, architecture, and PostgreSQL version you selected
 - Confirm the PostgreSQL upstream repository was added before the DocumentDB package install
+- If you use the host gateway flow, confirm \`PG_VERSION_USED\` matches the PostgreSQL major version you installed
+- If \`./scripts/build_and_start_gateway.sh\` fails, confirm \`git\`, \`cargo\`, and \`rustc\` are installed on the host
+- If \`mongosh\` cannot connect, confirm the gateway script is still running and listening on port \`10260\`
 - For Debian 11, use PostgreSQL 16 or 17; PostgreSQL 18 is blocked by the upstream Bullseye PostGIS dependency
 - If you need a gateway endpoint, use DocumentDB Local with Docker or build and run the gateway from source
 

--- a/app/services/articleService.ts
+++ b/app/services/articleService.ts
@@ -116,6 +116,10 @@ Use the [Package Finder](/packages) to generate the exact install command for yo
 > The generated command installs the PostgreSQL extension package and its PostgreSQL-side dependencies. The published package repository and GitHub Releases do not currently include a gateway package, setup helper, or systemd service.
 >
 > The repository-backed install commands currently cover Ubuntu 22.04/24.04, Debian 11/12/13, and RHEL-compatible 8/9 systems. Debian 11 currently resolves PostgreSQL 16 and 17 in the repository-backed flow.
+>
+> The package commands assume a regular Linux host where you use \`sudo\`. If you are testing in a clean container that already runs as \`root\`, omit \`sudo\` from the package-install commands.
+>
+> On Debian and Ubuntu in a clean container, also run \`export DEBIAN_FRONTEND=noninteractive\` in the shell before the APT commands. Without it, \`tzdata\` (and a few other packages) prompt for input during \`apt install\` and the install hangs with no visible error.
 
 ## Install the packages
 
@@ -168,28 +172,59 @@ If you want to keep PostgreSQL on the host and still connect with \`mongosh\`, i
 ### Prerequisites for the host gateway step
 
 - [Git](https://git-scm.com/)
-- A Rust toolchain (\`cargo\` + \`rustc\`)
+- \`curl\`
+- Native build tools for Rust crates that link against OpenSSL
+- A current Rust toolchain via \`rustup\`
 - [mongosh](https://www.mongodb.com/docs/mongodb-shell/install/)
 
-Install Git and Rust with your distro package manager before continuing. Examples:
+Run the PostgreSQL and gateway steps from an unprivileged user account, not \`root\`. PostgreSQL will not initialize as \`root\`.
+
+If you are following these steps in a clean container that starts as \`root\`, finish the package-install commands as \`root\`, then switch to an unprivileged account such as \`postgres\` before you start PostgreSQL or the gateway.
+
+\`\`\`bash
+# from a root shell inside the container
+su - postgres
+\`\`\`
+
+Install the host prerequisites with your distro package manager before continuing. Examples:
 
 \`\`\`bash
 # Debian / Ubuntu
-sudo apt install -y git rustc cargo
+sudo apt install -y git curl build-essential pkg-config libssl-dev
 
 # RHEL-compatible
-sudo dnf install -y git rust cargo
+sudo dnf install -y git curl gcc gcc-c++ make pkgconf-pkg-config openssl-devel
 \`\`\`
+
+Install a current Rust toolchain with \`rustup\`, then load it into your shell:
+
+\`\`\`bash
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+. "$HOME/.cargo/env"
+\`\`\`
+
+In a clean container that starts as \`root\`, install the system packages above and install \`mongosh\` while you are still \`root\`. Then switch to the unprivileged user and run the \`rustup\` commands plus the remaining gateway steps from that user's shell.
 
 ### Host setup example
 
 Replace \`<PG_MAJOR>\` with the PostgreSQL major version you installed from the package repository, such as \`16\`, \`17\`, or \`18\`.
+
+If you do not already have \`mongosh\`, install it with the official MongoDB shell instructions for your distro before continuing:
+
+- https://www.mongodb.com/docs/mongodb-shell/install/
 
 \`\`\`bash
 git clone https://github.com/documentdb/documentdb.git
 cd documentdb
 
 export PG_VERSION_USED=<PG_MAJOR>
+
+# Required in non-interactive shells (CI, \`docker exec\` without \`-t\`,
+# \`docker exec -d\`, \`nohup\`, background \`&\`). build_and_start_gateway.sh
+# calls \`tput\` for colored output and aborts under \`set -u\` / \`set -e\` if
+# TERM is unset or set to \`dumb\`. Skip this line in a normal interactive
+# terminal where TERM is already \`xterm\`, \`xterm-256color\`, etc.
+export TERM=xterm
 
 ./scripts/start_oss_server.sh -c -u <YOUR_USERNAME> -a <YOUR_PASSWORD>
 
@@ -200,6 +235,8 @@ export PG_VERSION_USED=<PG_MAJOR>
 \`\`\`
 
 \`./scripts/start_oss_server.sh -c\` initializes a fresh local PostgreSQL data directory under \`~/.documentdb/data\`. \`./scripts/build_and_start_gateway.sh -c\` forces a clean gateway rebuild; after the first successful build, you can omit \`-c\` on later restarts.
+
+The first gateway build downloads several hundred Rust crates and typically takes a few minutes on a fresh machine before the gateway begins listening on port \`10260\`. Subsequent runs without \`-c\` are much faster.
 
 Keep the gateway command running in the foreground. It starts the MongoDB-compatible endpoint on port \`10260\` and connects it to PostgreSQL on port \`9712\`.
 
@@ -223,8 +260,12 @@ If something does not work on the first try:
 - Confirm the extension package is installed: \`postgresql-<PG>-documentdb\` on APT or \`postgresql<PG>-documentdb\` on RPM
 - Re-run the Package Finder command for the exact distro, architecture, and PostgreSQL version you selected
 - Confirm the PostgreSQL upstream repository was added before the DocumentDB package install
+- If you are running in a clean container as \`root\`, omit \`sudo\` from the package-install commands and switch to an unprivileged user before the gateway steps
+- If \`apt install\` hangs forever in a clean container, run \`export DEBIAN_FRONTEND=noninteractive\` in that shell and re-run the install; the default front-end is waiting for a \`tzdata\` prompt that never gets typed
 - If you use the host gateway flow, confirm \`PG_VERSION_USED\` matches the PostgreSQL major version you installed
-- If \`./scripts/build_and_start_gateway.sh\` fails, confirm \`git\`, \`cargo\`, and \`rustc\` are installed on the host
+- If \`./scripts/build_and_start_gateway.sh\` exits immediately with \`tput: No value for $TERM\` (or silently with \`set -e\` when \`TERM=dumb\`), set \`export TERM=xterm\` before re-running, or run the script from an interactive shell (for Docker, \`docker exec -it ...\`)
+- If \`./scripts/build_and_start_gateway.sh\` fails, confirm \`git\`, \`curl\`, native build tools, \`pkg-config\`, OpenSSL headers, and a current Rust toolchain are installed on the host
+- If the gateway build fails while reading \`Cargo.lock\`, switch to a current Rust toolchain from \`rustup\` instead of the distro-packaged \`cargo\`
 - If \`mongosh\` cannot connect, confirm the gateway script is still running and listening on port \`10260\`
 - For Debian 11, use PostgreSQL 16 or 17; PostgreSQL 18 is blocked by the upstream Bullseye PostGIS dependency
 - If you need a gateway endpoint, use DocumentDB Local with Docker or build and run the gateway from source

--- a/app/services/articleService.ts
+++ b/app/services/articleService.ts
@@ -107,15 +107,15 @@ If something does not work as expected:
 
 const linuxPackagesGuideContent = `# Linux Packages Quick Start
 
-Install DocumentDB on Debian, Ubuntu, or RHEL-family hosts with repository-backed packages.
+Install the DocumentDB PostgreSQL extension package on Debian, Ubuntu, or RHEL-compatible hosts.
 
 ## Choose the right package command
 
 Use the [Package Finder](/packages) to generate the exact install command for your distro, architecture, and PostgreSQL version.
 
-> The generated command installs both the PostgreSQL extension package and the gateway package required for MongoDB-compatible connections on port \`10260\`.
+> The generated command installs the PostgreSQL extension package and its PostgreSQL-side dependencies. The published package repository does not currently include a gateway package, setup helper, or systemd service.
 >
-> The repository-backed install commands currently cover Ubuntu 22.04/24.04, Debian 11/12/13, and RHEL-family 8/9 systems. Debian 11 currently resolves PostgreSQL 16 and 17 in the repository-backed flow.
+> The repository-backed install commands currently cover Ubuntu 22.04/24.04, Debian 11/12/13, and RHEL-compatible 8/9 systems. Debian 11 currently resolves PostgreSQL 16 and 17 in the repository-backed flow.
 
 ## Install the packages
 
@@ -131,82 +131,56 @@ ${buildAptInstallCommand('ubuntu24', 'amd64', '16')}
 ${buildRpmInstallCommand('rhel9', 'x86_64', '16')}
 \`\`\`
 
-## Initialize and start DocumentDB
+## What the package installs
 
-After the packages are installed, run the packaged setup command:
+The packages install the DocumentDB PostgreSQL extension files for the selected PostgreSQL major version. They do not start a MongoDB-compatible gateway endpoint on port \`10260\`.
 
-\`\`\`bash
-sudo documentdb-setup \\
-  --username <YOUR_USERNAME> \\
-  --password <YOUR_PASSWORD> \\
-  --pg-version 16 \\
-  --load-sample-data
-\`\`\`
-
-> If you selected PostgreSQL 17 or 18 in the Package Finder, use that version in \`--pg-version\`.
->
-> If you want to attach DocumentDB to an existing PostgreSQL cluster instead of creating a new local cluster, use \`--skip-pg-init --pg-port <PORT>\`.
-
-## Verify the setup
-
-Use the gateway service status and \`mongosh\` to confirm the host install is ready:
+Use the Docker quick start when you need the fastest local gateway-backed DocumentDB endpoint:
 
 \`\`\`bash
-sudo systemctl status documentdb-gateway --no-pager
-
-mongosh localhost:10260 \\
-  -u <YOUR_USERNAME> \\
-  -p <YOUR_PASSWORD> \\
-  --authenticationMechanism SCRAM-SHA-256 \\
-  --tls \\
-  --tlsAllowInvalidCertificates
-\`\`\`
-
-Then run a quick health check and inspect the sample data:
-
-\`\`\`javascript
-db.runCommand({ ping: 1 })
-
-use sampledb
-
-db.users.find({}, { name: 1, email: 1, _id: 0 }).limit(3)
-\`\`\`
-
-If you skipped \`--load-sample-data\`, create your own collection instead of querying \`sampledb\`.
-
-## Existing PostgreSQL clusters and custom ports
-
-\`\`\`bash
-sudo documentdb-setup \\
-  --skip-pg-init \\
-  --pg-port 5432 \\
-  --gateway-port 10260 \\
+docker run -dt --name documentdb \\
+  -p 10260:10260 \\
+  ghcr.io/documentdb/documentdb/documentdb-local:latest \\
   --username <YOUR_USERNAME> \\
   --password <YOUR_PASSWORD>
 \`\`\`
 
-Use \`--data-dir\` and \`--pg-owner\` when your environment needs explicit PostgreSQL paths or ownership settings.
+If you are operating a host PostgreSQL installation, configure PostgreSQL and run the gateway using the source repository's build/run scripts.
+
+## Verify the package install
+
+Use package-manager metadata to confirm the extension package is installed:
+
+\`\`\`bash
+# APT
+apt-cache policy postgresql-16-documentdb
+dpkg -L postgresql-16-documentdb | grep -E 'documentdb.*\\.(control|sql|so)$' | head
+
+# RPM
+dnf info postgresql16-documentdb
+rpm -ql postgresql16-documentdb | grep -E 'documentdb.*\\.(control|sql|so)$' | head
+\`\`\`
 
 ## Troubleshooting and debugging
 
 If something does not work on the first try:
 
-- Confirm both packages are installed: \`postgresql-<PG>-documentdb\` plus \`documentdb_gateway\` on APT, or \`postgresql<PG>-documentdb\` plus \`documentdb-gateway\` on RPM
-- Re-run \`documentdb-setup --help\` to review cluster, port, and sample-data options
-- Use \`sudo documentdb-setup --verbose ...\` for more detailed setup output
-- Check the gateway service with \`sudo systemctl status documentdb-gateway\`
-- Inspect recent gateway logs with \`sudo journalctl -u documentdb-gateway --no-pager -n 50\`
-- If setup reports a PostgreSQL port or cluster conflict, use \`--skip-pg-init\` or choose a different \`--pg-port\`
+- Confirm the extension package is installed: \`postgresql-<PG>-documentdb\` on APT or \`postgresql<PG>-documentdb\` on RPM
+- Re-run the Package Finder command for the exact distro, architecture, and PostgreSQL version you selected
+- Confirm the PostgreSQL upstream repository was added before the DocumentDB package install
+- For Debian 11, use PostgreSQL 16 or 17; PostgreSQL 18 is blocked by the upstream Bullseye PostGIS dependency
+- If you need a gateway endpoint, use DocumentDB Local with Docker or build and run the gateway from source
 
 ## Next steps
 
+- [Docker Quick Start](/docs/getting-started/docker)
+- [Building from source](https://github.com/documentdb/documentdb/blob/main/docs/v1/building.md)
 - [Mongo Shell Quick Start](/docs/getting-started/mongo-shell-quickstart)
 - [Node.js Quick Start](/docs/getting-started/nodejs-setup)
 - [Python Quick Start](/docs/getting-started/python-setup)
 - [API Reference](/docs/reference)
 - [Samples Gallery](/samples)
 - [Package Finder](/packages)
-- [Docker Quick Start](/docs/getting-started/docker)
 `;
 
 const vscodeQuickStartGuideContent = `# Visual Studio Code Quick Start
@@ -217,7 +191,7 @@ Use DocumentDB for VS Code to connect to a local DocumentDB instance, browse sam
 
 - [Visual Studio Code](https://code.visualstudio.com/)
 - The [DocumentDB for VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-documentdb)
-- A local DocumentDB instance from [Docker Quick Start](/docs/getting-started/docker) or [Linux Packages Quick Start](/docs/getting-started/packages)
+- A local DocumentDB instance from [Docker Quick Start](/docs/getting-started/docker) or a host setup with a running DocumentDB gateway
 - Optional: [mongosh](https://www.mongodb.com/docs/mongodb-shell/install/) for independent connection checks
 
 ## Install the extension
@@ -242,7 +216,7 @@ docker run -dt --name documentdb \\
   --password <YOUR_PASSWORD>
 \`\`\`
 
-If you prefer a host installation instead of Docker, use [Linux Packages Quick Start](/docs/getting-started/packages) and complete the \`documentdb-setup\` step first.
+If you prefer a host installation instead of Docker, use [Linux Packages Quick Start](/docs/getting-started/packages) for the PostgreSQL extension package and run the gateway from source.
 
 ## Add a local connection in VS Code
 
@@ -289,7 +263,7 @@ If the extension does not connect on the first try:
 - Verify the extension is installed and reload VS Code if the DocumentDB view does not appear
 - Confirm your local DocumentDB instance is actually running before you connect
 - If you used Docker, check \`docker ps\` and \`docker logs documentdb\`
-- If you used Linux packages, check \`sudo systemctl status documentdb-gateway\` and \`sudo journalctl -u documentdb-gateway --no-pager -n 50\`
+- If you used a host-built gateway, confirm the gateway process is running and listening on the port you entered
 - If the local connection wizard fails on security, retry and choose the TLS/SSL option that matches your certificate setup
 - Use \`mongosh\` to confirm the endpoint works independently of VS Code
 
@@ -447,7 +421,7 @@ docker run -dt --name documentdb \\
   --password <YOUR_PASSWORD>
 \`\`\`
 
-If you prefer a host installation instead of Docker, use [Linux Packages Quick Start](/docs/getting-started/packages) and complete the \`documentdb-setup\` step first.
+If you prefer a host installation instead of Docker, use [Linux Packages Quick Start](/docs/getting-started/packages) for the PostgreSQL extension package and run the gateway from source.
 
 > DocumentDB Local uses a self-signed certificate by default, so the quickest local
 > PyMongo connection uses \`tlsAllowInvalidCertificates=true\`.
@@ -550,7 +524,7 @@ If the Python quick start does not work on the first try:
 
 - Verify your local DocumentDB instance is running before you start Python
 - If you used Docker, check \`docker ps --filter "name=documentdb"\` and \`docker logs documentdb\`
-- If you used Linux packages, check \`sudo systemctl status documentdb-gateway\` and \`sudo journalctl -u documentdb-gateway --no-pager -n 50\`
+- If you used a host-built gateway, confirm the gateway process is running and listening on port \`10260\`
 - If Python cannot import \`pymongo\`, verify the active interpreter with \`python -c "import sys; print(sys.executable)"\` and reinstall with \`python -m pip install pymongo\`
 - If you see TLS or certificate errors, either use the default local self-signed flow with \`tlsAllowInvalidCertificates=true\` or switch to a trusted local certificate with \`tlsCAFile\`
 - Use [Mongo Shell Quick Start](/docs/getting-started/mongo-shell-quickstart) to validate the endpoint independently of your application code
@@ -587,7 +561,7 @@ docker run -dt --name documentdb \\
   --password <YOUR_PASSWORD>
 \`\`\`
 
-If you prefer a host installation instead of Docker, use [Linux Packages Quick Start](/docs/getting-started/packages) and complete the \`documentdb-setup\` step first.
+If you prefer a host installation instead of Docker, use [Linux Packages Quick Start](/docs/getting-started/packages) for the PostgreSQL extension package and run the gateway from source.
 
 > Replace \`<YOUR_USERNAME>\` and \`<YOUR_PASSWORD>\` with your own credentials.
 >
@@ -675,8 +649,8 @@ If \`mongosh\` does not connect on the first try:
 
 - Verify the local DocumentDB instance is running before you connect
 - If you used Docker, check \`docker ps --filter "name=documentdb"\` and \`docker logs documentdb\`
-- If you used Linux packages, check \`sudo systemctl status documentdb-gateway\` and \`sudo journalctl -u documentdb-gateway --no-pager -n 50\`
-- If authentication fails, confirm the username and password you used when you started DocumentDB or ran \`documentdb-setup\`
+- If you used a host-built gateway, confirm the gateway process is running and listening on port \`10260\`
+- If authentication fails, confirm the username and password you used when you started DocumentDB
 - If TLS validation fails, either keep \`--tlsAllowInvalidCertificates\` for the default local self-signed setup or switch to \`--tlsCAFile\` with a trusted certificate
 - If \`mongosh\` is not installed, follow the [mongosh install guide](https://www.mongodb.com/docs/mongodb-shell/install/)
 - Use [Python Quick Start](/docs/getting-started/python-setup) or [Node.js Quick Start](/docs/getting-started/nodejs-setup) to verify the same endpoint from an application driver
@@ -1099,7 +1073,7 @@ export function getArticleByPath(section: string, slug: string[] = []): {
       content: linuxPackagesGuideContent,
       frontmatter: {
         title: articleTitleOverrides[getArticleKey(section, file)],
-        description: 'Install DocumentDB with Linux packages, run documentdb-setup, verify the gateway, and find troubleshooting guidance.',
+        description: 'Install the DocumentDB PostgreSQL extension with Linux packages and find package troubleshooting guidance.',
       },
       navigation,
       section,


### PR DESCRIPTION
## Summary

Fixes the Linux package install experience on `/packages` and `/docs/getting-started/packages` so the website matches the packages that are actually published. Repository-backed installs provide the DocumentDB PostgreSQL extension package; they do not currently provide a gateway package, setup helper, or systemd service.

The updated guide now gives users a path from package install to successful `mongosh` connectivity: install the extension package, start PostgreSQL with the packaged extension, build/run the gateway from source, and verify the endpoint with `mongosh`.

## What changed

- Remove nonexistent `documentdb_gateway` / `documentdb-gateway` packages from generated APT/RPM commands.
- Remove the nonexistent `documentdb-setup` follow-up flow from the Package Finder UI and package guide.
- Clarify that Linux packages install PostgreSQL extension files, while Docker remains the shortest gateway-backed local setup.
- Add clean Docker container guidance: omit `sudo`, set `DEBIAN_FRONTEND=noninteractive` before APT commands, install prerequisites and `mongosh` as `root`, then switch to an unprivileged user for PostgreSQL/gateway steps.
- Add gateway-from-source guidance, including the `TERM=xterm` workaround for non-TTY shells and troubleshooting notes for package install/gateway startup issues.
- Keep `PACKAGE-INSTALL.md` aligned with the rendered website package guide.

## Verification

End-to-end package install flow was tested in a fresh Ubuntu amd64 Docker container:

1. Ran the generated APT package command for `postgresql-16-documentdb`.
2. Confirmed the package installed and exposed the DocumentDB extension files.
3. Started PostgreSQL with the packaged extension using `./scripts/start_oss_server.sh`.
4. Built and started the gateway from source using `./scripts/build_and_start_gateway.sh`.
5. Connected with `mongosh localhost:10260 ...` and verified `db.runCommand({ ping: 1 })` returns `{ ok: 1 }`.

Repo checks were run for the changed website files.