### PR TITLE
Restore MongoDB-compatible callout in homepage hero

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -312,7 +312,7 @@ export default function Home() {
                 DocumentDB
               </h1>
               <p className="mb-4 max-w-3xl text-2xl font-semibold tracking-tight text-white sm:text-3xl">
-                Built for document workloads. Powered by PostgreSQL.
+                A powerful, scalable, MongoDB compatible open-source document database built for modern applications
               </p>
               <p className="mb-7 max-w-xl text-base leading-7 text-gray-300 sm:text-lg">
                 Open source and MIT licensed, with native BSON, advanced


### PR DESCRIPTION
## Summary

Brings back the prior hero subtitle that called out DocumentDB as a MongoDB compatible open-source document database.

## Background

- The line was originally added in #6 (`Update description to specify MongoDB compatibility`).
- It was removed during the homepage refresh in #61 (`Refresh homepage and download experience`) in favor of `Built for document workloads. Powered by PostgreSQL.`
- This PR restores the original wording in the same hero subtitle slot so the MongoDB compatibility messaging is visible above the fold again.

## Change

`app/page.tsx` hero subtitle:

- Before: `Built for document workloads. Powered by PostgreSQL.`
- After:  `A powerful, scalable, MongoDB compatible open-source document database built for modern applications`

The smaller PostgreSQL-focused descriptor below it (`Open source and MIT licensed, with native BSON, advanced indexing, and vector search on PostgreSQL.`) is intentionally left unchanged, so the Postgres callout remains alongside the restored line.

## Test plan

- Text-only swap inside an existing `<p>` element; no JSX or component structure changes.
- No new dependencies, routes, or APIs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>