### PR TITLE
Update version references for v0.111-0 release

### DIFF
--- a/PACKAGE-INSTALL.md
+++ b/PACKAGE-INSTALL.md
@@ -252,9 +252,9 @@ GitHub Releases contains `.deb` and `.rpm` extension assets for every published 
 Examples:
 
 ```text
-ubuntu22.04-postgresql-18-documentdb_0.110-0_amd64.deb
-deb13-postgresql-18-documentdb_0.110-0_amd64.deb
-rhel9-postgresql18-documentdb-0.110.0-1.el9.x86_64.rpm
+ubuntu22.04-postgresql-18-documentdb_0.111-0_amd64.deb
+deb13-postgresql-18-documentdb_0.111-0_amd64.deb
+rhel9-postgresql18-documentdb-0.111.0-1.el9.x86_64.rpm
 ```
 
 - GitHub Releases: https://github.com/documentdb/documentdb/releases

--- a/app/packages/page.tsx
+++ b/app/packages/page.tsx
@@ -50,8 +50,8 @@ const nextGuides = [
 ] as const;
 
 const allReleasesUrl = "https://github.com/documentdb/documentdb/releases";
-const currentAptVersionExample = "0.110-0";
-const currentRpmVersionExample = "0.110.0-1.el9";
+const currentAptVersionExample = "0.111-0";
+const currentRpmVersionExample = "0.111.0-1.el9";
 const currentReleaseExamples = [
   `ubuntu22.04-postgresql-18-documentdb_${currentAptVersionExample}_amd64.deb`,
   `deb13-postgresql-18-documentdb_${currentAptVersionExample}_amd64.deb`,


### PR DESCRIPTION
## Summary

Updates version examples on the website packages page and PACKAGE-INSTALL.md for the v0.111-0 release.

## Changes

- `app/packages/page.tsx`: Update `currentAptVersionExample` and `currentRpmVersionExample` from 0.110-0 to 0.111-0
- `PACKAGE-INSTALL.md`: Update example filenames from 0.110-0 to 0.111-0

## Related

- Engine release: https://github.com/documentdb/documentdb/releases/tag/v0.111-0
- Docs PR: https://github.com/documentdb/docs/pull/45