### PR TITLE
Update version references for v0.112-0 release

### DIFF
--- a/PACKAGE-INSTALL.md
+++ b/PACKAGE-INSTALL.md
@@ -252,9 +252,9 @@ GitHub Releases contains `.deb` and `.rpm` extension assets for every published 
 Examples:
 
 ```text
-ubuntu22.04-postgresql-18-documentdb_0.111-0_amd64.deb
-deb13-postgresql-18-documentdb_0.111-0_amd64.deb
-rhel9-postgresql18-documentdb-0.111.0-1.el9.x86_64.rpm
+ubuntu22.04-postgresql-18-documentdb_0.112-0_amd64.deb
+deb13-postgresql-18-documentdb_0.112-0_amd64.deb
+rhel9-postgresql18-documentdb-0.112.0-1.el9.x86_64.rpm
 ```
 
 - GitHub Releases: https://github.com/documentdb/documentdb/releases

--- a/app/packages/page.tsx
+++ b/app/packages/page.tsx
@@ -50,8 +50,8 @@ const nextGuides = [
 ] as const;
 
 const allReleasesUrl = "https://github.com/documentdb/documentdb/releases";
-const currentAptVersionExample = "0.111-0";
-const currentRpmVersionExample = "0.111.0-1.el9";
+const currentAptVersionExample = "0.112-0";
+const currentRpmVersionExample = "0.112.0-1.el9";
 const currentReleaseExamples = [
   `ubuntu22.04-postgresql-18-documentdb_${currentAptVersionExample}_amd64.deb`,
   `deb13-postgresql-18-documentdb_${currentAptVersionExample}_amd64.deb`,


### PR DESCRIPTION
Bumps the APT and RPM version examples shown on the Package Finder page and in PACKAGE-INSTALL.md from `0.111` to `0.112` for the [v0.112-0 release](https://github.com/documentdb/documentdb/releases/tag/v0.112-0).

### Changes

- `PACKAGE-INSTALL.md` - bump direct-download filename examples to `0.112`.
- `app/packages/page.tsx` - bump `currentAptVersionExample` and `currentRpmVersionExample` to `0.112`.

### Validation

- `npm run lint` passes.

Follows the same pattern as #77 (v0.111-0) and #71 (v0.110-0).