### PR TITLE
Update version references for v0.113-0 release

### DIFF
--- a/PACKAGE-INSTALL.md
+++ b/PACKAGE-INSTALL.md
@@ -252,9 +252,9 @@ GitHub Releases contains `.deb` and `.rpm` extension assets for every published 
 Examples:
 
 ```text
-ubuntu22.04-postgresql-18-documentdb_0.112-0_amd64.deb
-deb13-postgresql-18-documentdb_0.112-0_amd64.deb
-rhel9-postgresql18-documentdb-0.112.0-1.el9.x86_64.rpm
+ubuntu22.04-postgresql-18-documentdb_0.113-0_amd64.deb
+deb13-postgresql-18-documentdb_0.113-0_amd64.deb
+rhel9-postgresql18-documentdb-0.113.0-1.el9.x86_64.rpm
 ```
 
 - GitHub Releases: https://github.com/documentdb/documentdb/releases

--- a/app/packages/page.tsx
+++ b/app/packages/page.tsx
@@ -50,8 +50,8 @@ const nextGuides = [
 ] as const;
 
 const allReleasesUrl = "https://github.com/documentdb/documentdb/releases";
-const currentAptVersionExample = "0.112-0";
-const currentRpmVersionExample = "0.112.0-1.el9";
+const currentAptVersionExample = "0.113-0";
+const currentRpmVersionExample = "0.113.0-1.el9";
 const currentReleaseExamples = [
   `ubuntu22.04-postgresql-18-documentdb_${currentAptVersionExample}_amd64.deb`,
   `deb13-postgresql-18-documentdb_${currentAptVersionExample}_amd64.deb`,


### PR DESCRIPTION
Bumps the documented APT/RPM install examples from 0.112 to **0.113**:

- `PACKAGE-INSTALL.md`: example `.deb`/`.rpm` filenames → `0.113-0` / `0.113.0-1.el9`
- `app/packages/page.tsx`: `currentAptVersionExample = "0.113-0"`, `currentRpmVersionExample = "0.113.0-1.el9"`

Merging to `main` triggers the `continuous-deployment` workflow, which republishes the APT/RPM package repositories from the latest DocumentDB release (now [v0.113-0](https://github.com/documentdb/documentdb/releases/tag/v0.113-0), already published with its 42 deb/rpm assets). Mirrors PR #78 (v0.112-0).