### PR TITLE
Update version references for v0.114-0 release

### DIFF
--- a/PACKAGE-INSTALL.md
+++ b/PACKAGE-INSTALL.md
@@ -252,9 +252,9 @@ GitHub Releases contains `.deb` and `.rpm` extension assets for every published 
 Examples:
 
 ```text
-ubuntu22.04-postgresql-18-documentdb_0.113-0_amd64.deb
-deb13-postgresql-18-documentdb_0.113-0_amd64.deb
-rhel9-postgresql18-documentdb-0.113.0-1.el9.x86_64.rpm
+ubuntu22.04-postgresql-18-documentdb_0.114-0_amd64.deb
+deb13-postgresql-18-documentdb_0.114-0_amd64.deb
+rhel9-postgresql18-documentdb-0.114.0-1.el9.x86_64.rpm
 ```
 
 - GitHub Releases: https://github.com/documentdb/documentdb/releases

--- a/app/packages/page.tsx
+++ b/app/packages/page.tsx
@@ -50,8 +50,8 @@ const nextGuides = [
 ] as const;
 
 const allReleasesUrl = "https://github.com/documentdb/documentdb/releases";
-const currentAptVersionExample = "0.113-0";
-const currentRpmVersionExample = "0.113.0-1.el9";
+const currentAptVersionExample = "0.114-0";
+const currentRpmVersionExample = "0.114.0-1.el9";
 const currentReleaseExamples = [
   `ubuntu22.04-postgresql-18-documentdb_${currentAptVersionExample}_amd64.deb`,
   `deb13-postgresql-18-documentdb_${currentAptVersionExample}_amd64.deb`,


### PR DESCRIPTION
Bumps the APT/RPM install examples to `0.114` for the v0.114-0 release:

- `PACKAGE-INSTALL.md` — the three direct-download example filenames (deb x2, rpm).
- `app/packages/page.tsx` — `currentAptVersionExample` (`0.114-0`) and `currentRpmVersionExample` (`0.114.0-1.el9`); the packages-page examples are templated off these.

Verified the example asset names exist in the published [v0.114-0 release](https://github.com/documentdb/documentdb/releases/tag/v0.114-0). Follows the same pattern as #77/#78/#79.