### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+# Automated dependency updates.
+#
+# Dependabot runs on GitHub's infrastructure, so lockfile updates always
+# resolve against the public npm registry. This keeps `resolved` URLs in
+# package-lock.json canonical regardless of any registry proxy a
+# contributor may have configured locally.
+version: 2
+updates:
+  # Next.js site dependencies
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    # Only touch package.json when a bump requires it; in-range updates
+    # stay confined to package-lock.json.
+    versioning-strategy: increase-if-necessary
+    commit-message:
+      prefix: npm
+      include: scope
+    groups:
+      # Batch routine minor/patch bumps into a single PR to keep the
+      # review load low. Majors still arrive as individual PRs so each
+      # one can be evaluated on its own.
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Jekyll toolchain for the blogs section
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: bundler
+      include: scope
+    groups:
+      bundler-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Workflow actions (actions/checkout, actions/setup-node, ...)
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: actions
+    groups:
+      github-actions:
+        update-types:
+          - major
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to enable weekly automated dependency updates for the three ecosystems in this repo:

| Ecosystem | Covers | PR limit |
|---|---|---|
| `npm` | Next.js site dependencies | 5 |
| `bundler` | Jekyll toolchain for the blogs section | 3 |
| `github-actions` | Actions pinned in our workflows | 3 |

Routine **minor and patch** bumps are grouped into a single PR per ecosystem to keep review load low. **Major** bumps still arrive as individual PRs so each can be evaluated on its own.

The npm entry uses `versioning-strategy: increase-if-necessary`, so in-range updates stay confined to `package-lock.json`, and `package.json` is modified only when a bump genuinely requires a wider range.

## Why automate this rather than update lockfiles by hand

Beyond the usual convenience argument, there's a concrete correctness reason.

When `npm install` runs on a machine behind a corporate registry proxy, the proxy redirects to its backing feed and npm records the **post-redirect** URL. The result is a `package-lock.json` where every `resolved` entry points at an internal host instead of `registry.npmjs.org` — URLs that public CI and outside contributors cannot fetch. npm's `replace-registry-host` setting doesn't prevent this, because the redirect target isn't the configured registry host, so the rewrite never fires.

Dependabot runs on GitHub's infrastructure and resolves against the public npm registry directly, so `resolved` URLs stay canonical no matter how any individual contributor has npm configured locally.

## Note for maintainers

This file enables **version updates** only. Dependabot **security updates** — which open PRs for advisories ahead of the weekly schedule — are a separate repository setting under **Settings → Code security**, and need to be turned on by someone with admin access. Worth enabling: a current `npm audit` on `main` reports a critical advisory in `handlebars` (JS injection via AST type confusion) and a high in `js-yaml` (quadratic-complexity DoS), both fixable within the existing semver ranges.

## Testing

Config parses as valid YAML, and all field values (`package-ecosystem`, `versioning-strategy`, group `update-types`) were checked against the documented allowed values. No other files are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWCBtvyCpxc2aqtyLDhDeE
