### PR TITLE
Group the ESLint packages so peer-locked majors update together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,23 @@ updates:
       prefix: npm
       include: scope
     groups:
+      # The ESLint packages are peer-locked to each other and must move
+      # together. eslint-config-next@15 peer-requires
+      # eslint@"^7.23.0 || ^8.0.0 || ^9.0.0", so a lone eslint 10 bump
+      # fails to install with ERESOLVE; eslint-config-next@16 relaxes
+      # that to eslint@">=9.0.0". Grouping all update types, majors
+      # included, keeps them in a single installable PR. This group is
+      # listed first so it claims these packages before the catch-all
+      # group below.
+      eslint:
+        patterns:
+          - eslint
+          - eslint-config-next
+          - "@next/eslint-plugin-next"
+        update-types:
+          - major
+          - minor
+          - patch
       # Batch routine minor/patch bumps into a single PR to keep the
       # review load low. Majors still arrive as individual PRs so each
       # one can be evaluated on its own.


### PR DESCRIPTION
Fixes the root cause behind #89.

## The problem

The standalone `eslint` 10 bump in #89 cannot install. `eslint-config-next@15.5.4` peer-requires `eslint@"^7.23.0 || ^8.0.0 || ^9.0.0"`, so raising `eslint` on its own fails with `ERESOLVE` on **both** CI jobs:

```
npm error code ERESOLVE
npm error While resolving: eslint-config-next@15.5.4
npm error Found: eslint@10.8.0
npm error Could not resolve dependency:
npm error peer eslint@"^7.23.0 || ^8.0.0 || ^9.0.0" from eslint-config-next@15.5.4
npm error Conflicting peer dependency: eslint@9.39.5
```

`eslint-config-next@16` relaxes that peer to `eslint@">=9.0.0"`, so the two packages have to move in the same PR to be installable at all. Rebasing #89 does not help — the conflict is in the peer range, not in the branch. (#89 is now also `CONFLICTING` after #86 merged, but that is the lesser of its two problems.)

## The fix

Adds an `eslint` group covering `eslint`, `eslint-config-next`, and `@next/eslint-plugin-next`, with **all** update types including `major`, so Dependabot proposes them as one installable PR. The group is listed before the existing catch-all `npm-minor-and-patch` group so it claims these packages first.

Grouping majors is deliberate here and intentionally not the pattern for the rest of the tree. Majors normally warrant individual review, which the catch-all group preserves by matching only `minor` and `patch`. These three packages are the exception because their peer ranges make an individual bump uninstallable by construction.

## After merge

#89 can be closed. Dependabot will re-raise the upgrade as a combined PR on its next run, which will install cleanly and can be validated by CI in the normal way.

## Testing

Config parses as valid YAML; group ordering and all `update-types` values verified against the documented allowed set. No dependency versions change in this PR — it only changes how Dependabot proposes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWCBtvyCpxc2aqtyLDhDeE
