### PR TITLE
Move to TypeScript 6 and hold TypeScript 7 until Next.js supports it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,18 @@ updates:
     commit-message:
       prefix: npm
       include: scope
+    ignore:
+      # TypeScript 7 is the native port, and its compiler API is not the
+      # one Next.js links against. `next build` fails outright:
+      #   "TypeScript 7.0.2 does not provide the compiler API required by
+      #    Next.js. Enable experimental.useTypeScriptCli in your Next.js
+      #    config to use the TypeScript CLI, or install TypeScript 6
+      #    instead."
+      # Hold at 6.x until Next.js supports it, rather than reopening the
+      # same unmergeable PR every week.
+      - dependency-name: typescript
+        versions:
+          - 7.x
     groups:
       # The ESLint packages are peer-locked to each other and must move
       # together. eslint-config-next@15 peer-requires

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@eslint/eslintrc": "^3.3.3",
         "@next/eslint-plugin-next": "^16.1.1",
         "@tailwindcss/postcss": "^4.1.18",
-        "@types/js-yaml": "^4.0.9",
         "@types/minimatch": "^6.0.0",
         "@types/node": "^26.1.2",
         "@types/pluralize": "^0.0.33",
@@ -41,7 +40,7 @@
         "serve": "^14.2.5",
         "tailwindcss": "^4.1.18",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2288,13 +2287,6 @@
       "dependencies": {
         "@types/unist": "*"
       }
-    },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -10067,9 +10059,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@eslint/eslintrc": "^3.3.3",
     "@next/eslint-plugin-next": "^16.1.1",
     "@tailwindcss/postcss": "^4.1.18",
-    "@types/js-yaml": "^4.0.9",
     "@types/minimatch": "^6.0.0",
     "@types/node": "^26.1.2",
     "@types/pluralize": "^0.0.33",
@@ -51,6 +50,6 @@
     "serve": "^14.2.5",
     "tailwindcss": "^4.1.18",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
Supersedes #95.

## Why not TypeScript 7

Dependabot proposed TypeScript 7.0.2 in #95, which cannot build. TS 7 is the native port, and its compiler API is not the one Next.js links against:

```
Running TypeScript ...
TypeScript 7.0.2 does not provide the compiler API required by Next.js.
Enable experimental.useTypeScriptCli in your Next.js config to use the
TypeScript CLI, or install TypeScript 6 instead.
Next.js build worker exited with code: 1
```

This is not a problem with our code — TS 7 simply is not adoptable under Next.js 16 without opting into `experimental.useTypeScriptCli`.

## What this does

1. **Takes TypeScript 6**, the upgrade Next.js does support, rather than sitting on 5.9.3.
2. **Adds a `versions: [7.x]` ignore** so Dependabot stops reopening the same unmergeable PR every Monday. The ignore is scoped to the 7.x line only — 6.x updates still flow normally, and the entry can be deleted once Next.js supports the native port.
3. **Drops `@types/js-yaml`**, redundant since js-yaml 5 landed in #93. v5 ships its own declarations through its `types` export condition; the DefinitelyTyped package describes the v4 API and nothing uses it now.

## Testing

Generated and verified on a GitHub runner, not locally — this machine sits behind a corporate registry proxy that cannot reach `registry.npmjs.org`, so a locally produced lockfile would carry internal feed URLs that CI and outside contributors cannot fetch.

| Check | Result |
|---|---|
| `npm install` | pass |
| `npm run lint` | pass |
| `npm run build:next` | pass |
| Resolved URLs on `registry.npmjs.org` | 706 / 706 |

Worth noting the lint run was explicit: **upstream CI does not run `npm run lint`**, so the green checks on this PR alone would not prove the compiler change is clean. Adding a lint step to `continuous-integration.yml` would close that gap — happy to do it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWCBtvyCpxc2aqtyLDhDeE
