### PR TITLE
Make CI check what it claims to check

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -20,6 +20,10 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-22.04
+    # Without an explicit timeout a stalled step runs against GitHub's 6-hour
+    # default before failing, which for `pages` concurrency means blocking
+    # every deployment queued behind it.
+    timeout-minutes: 30
     steps:
       - name: Checkout source
         uses: actions/checkout@v7
@@ -132,6 +136,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs:
       - build
     # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,11 +9,19 @@ on:
   pull_request:
     branches:
       - main
+# Supersede in-flight runs for a pull request when new commits arrive, so a
+# rebase or force-push does not leave several runs racing on stale commits.
+# Pushes to main are never cancelled: every commit on the default branch
+# should get a recorded result.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   # YAML schema validation job
   yaml-schema-validation:
     name: Validate YAML files against schemas
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -21,18 +29,19 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 24
-      - name: Install dependencies
-        run: |
-          npm install yaml-ls-check
       - name: Validate YAML files
-        run: |
-          npx yaml-ls-check .\articles
-          npx yaml-ls-check .\blogs
-          npx yaml-ls-check .\reference
+        # Pass the repository root as an absolute path. yaml-ls-check reads its
+        # schema mapping from `<root>/.vscode/settings.json`, so the root it is
+        # given has to be the directory holding `.vscode`. Passing a
+        # subdirectory silently skips schema validation and checks only YAML
+        # syntax; passing a relative path breaks the mapping's `./schema/`
+        # references.
+        run: npx --yes yaml-ls-check "$GITHUB_WORKSPACE"
   # Build validation job
   build-validation:
     name: Validate Next.js build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -47,8 +56,28 @@ jobs:
         with:
           ruby-version: 3.3
           bundler-cache: true
+      - name: Check lockfile resolves against the public registry
+        # A lockfile generated behind a registry proxy records that proxy's
+        # backing-feed URLs, which public CI and outside contributors cannot
+        # fetch. Catch it here rather than after it is merged.
+        run: |
+          node -e "
+          const lock = require('./package-lock.json');
+          const bad = Object.entries(lock.packages)
+            .filter(([, v]) => v.resolved && !v.resolved.startsWith('https://registry.npmjs.org/'));
+          if (bad.length) {
+            console.error('package-lock.json has ' + bad.length + ' resolved URL(s) outside registry.npmjs.org:');
+            bad.slice(0, 10).forEach(([name, v]) => console.error('  ' + name + ' -> ' + v.resolved));
+            process.exit(1);
+          }
+          console.log('All resolved URLs point at registry.npmjs.org.');
+          "
       - name: Install dependencies
         run: npm ci
+      - name: Lint
+        # `next build` does not lint, so without this an ESLint or TypeScript
+        # upgrade can land without its effect on the lint rules ever running.
+        run: npm run lint
       - name: Build Next.js site
         # Validate that the site builds successfully
         #

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,13 @@ export default defineConfig([
       "coverage/**",
       "build/**",
       "node_modules/**",
+      // Jekyll vendors its gems into vendor/bundle when bundler-cache is on,
+      // which drops third-party JavaScript such as Jekyll's minified
+      // livereload.js into the tree. These paths are in .gitignore, but flat
+      // config does not read .gitignore, so they have to be listed here too.
+      "vendor/**",
+      ".jekyll-cache/**",
+      "**/_site/**",
     ],
   },
   {


### PR DESCRIPTION
Four fixes, each for something currently unguarded. No behaviour change to the site itself.

## 1. YAML schema validation has never validated anything

The step ran three commands that all point at paths which do not exist:

```yaml
npx yaml-ls-check .\articles
```

Those are Windows separators. On the Ubuntu runner bash treats `\a` as an escape, so the argument reaching the tool is `.articles`. Every run to date has printed:

```
Looking for YAML files to validate at: .articles
Validating 0 YAML files.
Validation complete.        # exit 0
```

**Correcting the paths alone would not have fixed it.** `yaml-ls-check` reads its schema mapping from `<root>/.vscode/settings.json`, where `<root>` is the directory you pass — so `yaml-ls-check articles` looks for `articles/.vscode/settings.json`, finds nothing, and silently degrades to syntax-only checking. A relative root fails differently: the mapping's `./schema/...` entries resolve to `/schema/...` and the schema cannot be loaded.

Passing the workspace as an **absolute path** is the form that works. Verified against a deliberately broken file:

```
articles/content.yml:1:1: Missing property "landing". yaml-schema: Articles Content Configuration
articles/content.yml:1:1: Property notLanding is not allowed.
EXIT=1
```

Against the tree as it stands it validates **11 files, all passing**, so this tightens the check without needing content changes.

The separate `npm install yaml-ls-check` step is also gone. It pulled in the entire project dependency tree as a side effect and wrote to `package.json` and `package-lock.json` inside CI; `npx --yes` fetches just the tool.

## 2. Lint never ran anywhere

`next build` does not lint, and no workflow invoked `npm run lint`. An ESLint or TypeScript upgrade could go green without its effect on the lint rules ever being exercised — which is exactly the situation the recent ESLint 10 and TypeScript 6 upgrades were in.

## 3. No job had a timeout

A stalled step ran against GitHub's 6-hour default before failing. Not hypothetical: a `Validate YAML files` step recently sat **over six minutes** on work that normally takes 24 seconds, and had to be cancelled by hand. The deployment workflow is the more serious case — its `pages` concurrency group means one stuck run blocks every deployment queued behind it.

Added: 10 min (YAML), 20 min (build), 30 min (deploy build), 10 min (deploy).

## 4. Nothing checked where the lockfile resolves from

A `package-lock.json` generated behind a corporate registry proxy records that proxy's backing-feed URLs rather than `registry.npmjs.org`. Those hosts are unreachable from public CI and by outside contributors, and the resulting failure surfaces far from its cause. The new step asserts every `resolved` URL points at the public registry and prints the offenders on failure. Dry-run against current `main`: **passes**.

## Plus: concurrency

A rebase or force-push now supersedes in-flight PR runs instead of leaving several racing on stale commits — during the recent Dependabot burst four runs were in flight at once. Pushes to `main` are never cancelled, so every default-branch commit keeps a recorded result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWCBtvyCpxc2aqtyLDhDeE
