### PR TITLE
Point the YAML schema mappings at files that exist

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,10 @@
 {
   "yaml.schemas": {
     "./schema/blog.content.schema.json": [
-      "blogs/content.{yml,yaml}"
+      "blogs/_data/posts.{yml,yaml}"
     ],
-    "./schema/reference.content.schema.json": [
-      "reference/content.{yml,yaml}"
+    "./schema/blog.categories.schema.json": [
+      "blogs/_data/categories.{yml,yaml}"
     ],
     "./schema/articles.content.schema.json": [
       "articles/**/content.{yml,yaml}"

--- a/schema/blog.categories.schema.json
+++ b/schema/blog.categories.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Blog Categories",
+  "description": "Defines the blog sources a post can be filed under. Each key is a category identifier referenced by the `category` field of an entry in blogs/_data/posts.yml, and the value supplies the labels rendered on the blog index.",
+  "type": "object",
+  "minProperties": 1,
+  "propertyNames": {
+    "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+    "description": "Lower-case kebab-case identifier, matched against the `category` field of a blog post."
+  },
+  "additionalProperties": {
+    "type": "object",
+    "required": ["label", "meta"],
+    "additionalProperties": false,
+    "properties": {
+      "label": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Human-readable name of the publication, shown as the heading for this category's group on the blog index (e.g. 'Microsoft Open Source Blog').",
+        "examples": ["DocumentDB Blog", "AWS Blogs"]
+      },
+      "meta": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Short qualifier displayed beside the label, used for a publication date or a note about the source (e.g. 'August 25, 2025', 'Partner Content').",
+        "examples": ["Recent", "Published here", "Partner Content"]
+      }
+    }
+  }
+}

--- a/schema/blog.content.schema.json
+++ b/schema/blog.content.schema.json
@@ -15,8 +15,9 @@
       },
       "category": {
         "type": "string",
-        "description": "A unique identifier representing the source or topical category of the blog post. This value determines which section or feed the post appears in. Must be one of: microsoft-open-source-blog, aws-blog, azure-cosmos-db-blog, yugabytedb-blog.",
+        "description": "A unique identifier representing the source or topical category of the blog post. This value determines which section or feed the post appears in, and must be a key defined in blogs/_data/categories.yml.",
         "enum": [
+          "documentdb-blog",
           "microsoft-open-source-blog",
           "aws-blog",
           "azure-cosmos-db-blog",


### PR DESCRIPTION
Follow-up to #98. That PR fixed the *invocation* so schema validation runs at all; with it running, two of the three mappings turn out to match nothing.

## The problem

```jsonc
"./schema/blog.content.schema.json":      ["blogs/content.{yml,yaml}"],       // no such file
"./schema/reference.content.schema.json": ["reference/content.{yml,yaml}"],   // schema file doesn't exist
"./schema/articles.content.schema.json":  ["articles/**/content.{yml,yaml}"], // the only live one
```

- There is no `blogs/content.yml` — the blog data lives in `blogs/_data/posts.yml`.
- `schema/reference.content.schema.json` is **not in the repository**, and `reference/` is generated at build time from [documentdb/docs](https://github.com/documentdb/docs) with no `content.yml` in it either.

Net effect: of the 11 YAML files the job validates, exactly **one** had a schema attached. The other ten were syntax-checked only.

## Changes

1. **Repoint the blog schema** at `blogs/_data/posts.{yml,yaml}`. The schema itself needed no restructuring — it's titled "Blog Post Link", an array of objects with `title`/`category`/`description`/`tags`/`uri`, which is exactly the shape of `posts.yml`. Only the glob was wrong.
2. **Drop the `reference/` mapping.** Its schema file doesn't exist and the directory is generated, not authored here.
3. **Add `blog.categories.schema.json`** for `blogs/_data/categories.yml`, which had no schema at all. It constrains the identifier format to kebab-case and requires `label` and `meta` on every entry.
4. **Add `documentdb-blog` to the category enum.** It's defined in `categories.yml` but was missing from the enum, so the first post filed under it would have failed validation for no good reason — a bug waiting to happen.

## Verification

Run with the same `yaml-ls-check "$PWD"` invocation CI uses.

**Current tree passes:** `Validating 11 YAML files. Validation complete.` (exit 0)

**Both new mappings reject bad input:**

```
posts.yml:14:13: Value is not accepted. Valid values: "documentdb-blog",
  "microsoft-open-source-blog", "aws-blog", ... yaml-schema: Blog Post Link

categories.yml:7:1: Missing property "label". yaml-schema: Blog Categories
```

Neither of those would have been caught before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWCBtvyCpxc2aqtyLDhDeE
