### PR TITLE
Serve the site at the domain root instead of /documentdb.github.io

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -77,9 +77,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Build with Next.js
+        # This repository is the organization Pages site served at the root of
+        # the custom domain (documentdb.io), so the build must NOT set
+        # NEXT_BASE_PATH. Setting it to the repository name (the usual trick
+        # for project pages) prefixes every internal link and asset URL with
+        # /documentdb.github.io/, which GitHub Pages then 301-redirects back
+        # to the root on every request and leaves the prefixed URL visible in
+        # the address bar after client-side navigation.
         env:
-          NEXT_BASE_PATH: ${{ github.event.repository.name }}
-          JEKYLL_BASE_PATH: /${{ github.event.repository.name }}/blogs
+          JEKYLL_BASE_PATH: /blogs
         run: npm run build
       - name: Download DocumentDB packages from latest release
         run: .github/scripts/download_packages.sh


### PR DESCRIPTION
## Problem

This repo is the **organization Pages site** with a custom domain — the deployed artifact is served at the root of `documentdb.io`. The deploy workflow builds with `NEXT_BASE_PATH: ${{ github.event.repository.name }}` (the standard trick for *project* pages), so every internal link and asset URL is emitted as `/documentdb.github.io/...`.

Verified against the live site:

- Every internal link, stylesheet, script, font, and image request to `documentdb.io/documentdb.github.io/...` gets a **301 redirect** back to the root path — an extra round trip on every asset of every page view, and the preloaded font is re-requested past the redirect.
- After any client-side navigation, the address bar shows `documentdb.io/documentdb.github.io/ai`-style URLs, which is what users copy and share.

```
$ curl -s -o /dev/null -w "%{http_code} %{redirect_url}" https://documentdb.io/documentdb.github.io/docs
301 https://documentdb.io/docs
```

## Fix

Drop `NEXT_BASE_PATH` and pin `JEKYLL_BASE_PATH` to `/blogs`, so generated URLs match where GitHub Pages actually serves the files. A comment in the workflow documents why this repo must not set a base path, to keep the project-pages trick from being reintroduced.

Existing indexed/shared `/documentdb.github.io/...` URLs keep working — GitHub Pages already 301s them to the root equivalents (that redirect is what made the current site navigable at all).

## Validation

- Workflow YAML parsed locally; the build step env is now exactly `{JEKYLL_BASE_PATH: /blogs}`.
- The `build-validation` CI job already builds **without** `NEXT_BASE_PATH`, so CI on this PR exercises exactly the configuration production will now ship (previously CI validated a different configuration than the deploy used).
- `app/services/sitePath.ts` and `next.config.ts` both handle the unset case explicitly (empty base path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGMeNSmhAgmqzkdc7cQQgf