### PR TITLE
Emit trailing-slash directories so /docs/ resolves on GitHub Pages

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,9 @@ const normalizedBasePath = rawBasePath
 
 const nextConfig: NextConfig = {
   output: "export",
+  // Emit directory/index.html instead of page.html so GitHub Pages serves
+  // both /docs and /docs/ (without this, the trailing-slash form is a 404).
+  trailingSlash: true,
   ...(normalizedBasePath
     ? {
         basePath: normalizedBasePath,


### PR DESCRIPTION
## Problem

The static export writes each page as `page.html`, which GitHub Pages serves for `/docs` but **not** for `/docs/` — the trailing-slash form that people naturally type and paste is a 404 today. Verified live:

```
$ curl -s -o /dev/null -w "%{http_code}" https://documentdb.io/docs
200
$ curl -s -o /dev/null -w "%{http_code}" https://documentdb.io/docs/
404
```

Every route on the site has this trap, and the 404 page users hit is the unbranded Next.js default.

## Fix

`trailingSlash: true` makes the export emit `docs/index.html` instead of `docs.html`. GitHub Pages then serves `/docs/` directly and 301s the bare `/docs` form to `/docs/`, so **both spellings of every route resolve**. Existing indexed no-slash URLs keep working via that redirect.

This also matches the Jekyll blogs section, which already uses `permalink: pretty` and produces `directory/index.html` output.

## Validation

- CI's `build-validation` job runs the full Next + Jekyll build with this setting; the reference pages with special characters in names (e.g. `$avg`) follow the same URL-decoding path GitHub Pages already handles for the `.html` form.
- Config-only change; `output: "export"` + `trailingSlash` is the documented Next.js configuration for static hosts like GitHub Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGMeNSmhAgmqzkdc7cQQgf