### PR TITLE
Add robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
## What

Adds an allow-all `public/robots.txt`, which the Next.js export copies to the site root (`documentdb.io/robots.txt`).

## Why

The live site returns a **404 for /robots.txt** today. An explicit robots.txt is the baseline crawlers expect; its absence is logged as an error by crawl tooling and leaves crawl policy implicit.

A `Sitemap:` directive is deliberately not included yet — the site has no sitemap.xml. That's a natural follow-up (build-time sitemap generation), at which point the directive can be added here.

## Validation

Static file; `public/` contents are copied verbatim into `out/` by the export build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGMeNSmhAgmqzkdc7cQQgf