### PR TITLE
Open only external docs links in a new tab

### DIFF
--- a/app/components/Markdown.tsx
+++ b/app/components/Markdown.tsx
@@ -244,18 +244,21 @@ function getMarkdownComponents() {
       );
     },
 
-    // Links
-    a: ({ children, href, ...props }: any) => (
-      <a
-        href={href}
-        className="text-blue-400 hover:text-blue-300 transition-colors"
-        target="_blank"
-        rel="noopener noreferrer"
-        {...props}
-      >
-        {children}
-      </a>
-    ),
+    // Links: only external links open in a new tab; internal links (/docs/...,
+    // /samples, #anchors) navigate in place
+    a: ({ children, href, ...props }: any) => {
+      const isExternal = /^https?:\/\//i.test(href ?? '');
+      return (
+        <a
+          href={href}
+          className="text-blue-400 hover:text-blue-300 transition-colors"
+          {...(isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+          {...props}
+        >
+          {children}
+        </a>
+      );
+    },
 
     // Strong text
     strong: ({ children, ...props }: any) => (


### PR DESCRIPTION
## Problem

`app/components/Markdown.tsx` renders **every** link in docs/reference content with `target="_blank"` — including site-internal links. The getting-started guides are chains of internal cross-links (Docker → Mongo Shell → Node.js → API Reference…), so normal docs reading spawns a new tab per click and users end up with a pile of tabs.

## Fix

Only links with an `http(s)://` scheme open in a new tab (keeping `rel="noopener noreferrer"`); internal paths (`/docs/...`, `/samples`, `/packages`) and in-page `#` anchors navigate in place.

## Validation

- Checked link inventory across the rendered content: guide bodies in `articleService.ts` and reference markdown from `documentdb/docs` use absolute internal paths (`/docs/...`) and external `https://` links (mongodb.com, github.com) — the scheme test cleanly separates the two.
- External links keep the exact current behavior; the `rel` hardening is unchanged for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGMeNSmhAgmqzkdc7cQQgf