### PR TITLE
Fix reference list descriptions to actually render italic

### DIFF
--- a/app/components/Grid.tsx
+++ b/app/components/Grid.tsx
@@ -16,7 +16,7 @@ export default function Grid({ items }: {
             <h4 className="text-blue-300 font-mono font-medium group-hover:text-blue-200">
               {page.name}
             </h4>
-            <p className="text-xs text-gray-400 font-italic">
+            <p className="text-xs text-gray-400 italic">
               {page.description}
             </p>
           </div>


### PR DESCRIPTION
## What

`app/components/Grid.tsx` styles reference-entry descriptions with `font-italic` — which is not a Tailwind class, so it resolves to nothing and the intended italic styling never rendered. Tailwind's font-style utilities are `italic` / `not-italic` ([docs](https://tailwindcss.com/docs/font-style)); this switches to the real one.

One-word diff, restores the intended visual distinction between the operator/command name (mono, blue) and its description on every reference listing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGMeNSmhAgmqzkdc7cQQgf