### PR TITLE
Give reference listing pages a real h1

### DIFF
--- a/app/docs/reference/[type]/[category]/page.tsx
+++ b/app/docs/reference/[type]/[category]/page.tsx
@@ -38,9 +38,9 @@ export default async function CommandReferencePage({ params }: { params: Promise
     <article>
       <Breadcrumb type={type} category={category} />
       <div className="mb-8">
-        <h2 className="text-4xl font-bold text-white mb-4 capitalize">
+        <h1 className="text-4xl font-bold text-white mb-4 capitalize">
           MongoDB Query Language (MQL) {capitalCase(category)} {capitalCase(pluralize(type))}
-        </h2>
+        </h1>
         <div className="w-24 h-1 bg-gradient-to-r from-blue-500 via-purple-500 to-green-500 rounded-full mb-6"></div>
         {description && (
           <div className="text-gray-400 text-lg mb-6">

--- a/app/docs/reference/[type]/page.tsx
+++ b/app/docs/reference/[type]/page.tsx
@@ -37,9 +37,9 @@ export default async function CommandReferencePage({ params }: { params: Promise
     <article>
       <Breadcrumb type={type} />
       <div className="mb-8">
-        <h2 className="text-4xl font-bold text-white mb-4 capitalize">
+        <h1 className="text-4xl font-bold text-white mb-4 capitalize">
           MongoDB Query Language (MQL) {capitalCase(pluralize(type))}
-        </h2>
+        </h1>
         <div className="w-24 h-1 bg-gradient-to-r from-blue-500 via-purple-500 to-green-500 rounded-full mb-6"></div>
         {description && (
           <div className="text-gray-400 text-lg mb-6">

--- a/app/docs/reference/page.tsx
+++ b/app/docs/reference/page.tsx
@@ -23,9 +23,9 @@ export default function Home() {
     <article>
       <Breadcrumb />
       <div className="mb-8">
-        <h2 className="text-4xl font-bold text-white mb-4">
+        <h1 className="text-4xl font-bold text-white mb-4">
           MongoDB Query Language (MQL)
-        </h2>
+        </h1>
         <div className="w-24 h-1 bg-gradient-to-r from-blue-500 via-purple-500 to-green-500 rounded-full mb-6"></div>
         {description && (
           <div className="text-gray-400 text-lg mb-6">


### PR DESCRIPTION
## What

The MQL reference **index**, **[type]**, and **[type]/[category]** pages render their top-level heading as `<h2>`, so those pages have no `h1` at all — a small but real accessibility and SEO defect (screen-reader landmark navigation and search snippets both key off `h1`).

Promotes the three headings to `h1` with identical styling classes.

## Validation

- Individual reference entry pages (`[name]`) are untouched — verified against `documentdb/docs` content that each entry's markdown starts with an `# h1` title (e.g. `api-reference/operators/accumulators/$avg.md`), so they already have a proper h1 via the Markdown renderer.
- Checked the `_metadata.description.md` files rendered under these headings (root, operators, commands, category level) — all plain paragraphs, no headings, so promoting the page title introduces no heading-order conflicts.
- The reference layout sidebar contains links only, no competing headings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGMeNSmhAgmqzkdc7cQQgf