### PR TITLE
Add social-share metadata and an Atom feed to the blog

### DIFF
--- a/blogs/_config.yml
+++ b/blogs/_config.yml
@@ -1,7 +1,8 @@
 title: DocumentDB Blog
 description: Insights, updates, and deep dives into the world of document databases and open-source innovation.
 baseurl: /blogs
-url: ""
+# Absolute host for og:url, og:image, and the Atom feed's permanent IDs.
+url: "https://documentdb.io"
 permalink: pretty
 markdown: kramdown
 kramdown:

--- a/blogs/_layouts/default.html
+++ b/blogs/_layouts/default.html
@@ -6,6 +6,33 @@
     <title>{% if page.title %}{{ page.title }} · {% endif %}DocumentDB</title>
     <meta name="description" content="{{ page.description | default: site.description | escape }}">
     <meta name="theme-color" content="#09090b">
+
+    {% assign social_title = page.title | default: site.title %}
+    {% assign social_description = page.description | default: site.description %}
+    {% if page.cover_image %}
+      {% if page.cover_image contains '://' %}
+        {% assign social_image = page.cover_image %}
+      {% else %}
+        {% assign social_image = page.cover_image | absolute_url %}
+      {% endif %}
+    {% else %}
+      {% assign social_image = site.url | append: '/images/social-card.png' %}
+    {% endif %}
+    <meta property="og:site_name" content="DocumentDB">
+    <meta property="og:type" content="{% if page.date %}article{% else %}website{% endif %}">
+    <meta property="og:title" content="{{ social_title | escape }}">
+    <meta property="og:description" content="{{ social_description | escape }}">
+    <meta property="og:url" content="{{ page.url | absolute_url }}">
+    <meta property="og:image" content="{{ social_image }}">
+    {% if page.date %}
+    <meta property="article:published_time" content="{{ page.date | date_to_xmlschema }}">
+    {% endif %}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="{{ social_title | escape }}">
+    <meta name="twitter:description" content="{{ social_description | escape }}">
+    <meta name="twitter:image" content="{{ social_image }}">
+
+    <link rel="alternate" type="application/atom+xml" title="DocumentDB Blog" href="{{ '/feed.xml' | relative_url }}">
     <link rel="stylesheet" href="{{ '/assets/blog.css' | relative_url }}">
   </head>
   <body>

--- a/blogs/feed.xml
+++ b/blogs/feed.xml
@@ -1,0 +1,28 @@
+---
+# layout: null opts out of the site-wide `layout: default` front-matter
+# default, which would otherwise wrap this XML in the HTML shell.
+layout: null
+permalink: /feed.xml
+---
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>{{ site.title | xml_escape }}</title>
+  <subtitle>{{ site.description | xml_escape }}</subtitle>
+  <id>{{ '/' | absolute_url }}</id>
+  <link href="{{ '/' | absolute_url }}"/>
+  <link href="{{ '/feed.xml' | absolute_url }}" rel="self"/>
+  <updated>{% if site.posts.size > 0 %}{{ site.posts.first.date | date_to_xmlschema }}{% else %}{{ site.time | date_to_xmlschema }}{% endif %}</updated>
+  <author><name>DocumentDB</name></author>
+  {% for post in site.posts %}
+  <entry>
+    <title>{{ post.title | xml_escape }}</title>
+    <id>{{ post.url | absolute_url }}</id>
+    <link href="{{ post.url | absolute_url }}"/>
+    <updated>{{ post.date | date_to_xmlschema }}</updated>
+    {% if post.author %}<author><name>{{ post.author | xml_escape }}</name></author>{% endif %}
+    {% if post.description %}<summary>{{ post.description | xml_escape }}</summary>{% endif %}
+    <content type="html">{{ post.content | xml_escape }}</content>
+    {% for tag in post.tags %}<category term="{{ tag | xml_escape }}"/>{% endfor %}
+  </entry>
+  {% endfor %}
+</feed>


### PR DESCRIPTION
## Problem

`blogs/_layouts/default.html` ships only `title`, `description`, and `theme-color` — **sharing any blog post on X/LinkedIn/Discord renders a bare link with no card**, which wastes announcement posts like the Kubernetes-operator launch. There's also no feed of any kind for aggregators and RSS readers.

## Fix

- **OG/Twitter tags** in the shared layout: `og:type=article` + `article:published_time` for dated posts, `website` elsewhere; the post's `cover_image` when present (absolute-ified via `absolute_url`), the site social card otherwise.
- **Atom feed** at `/blogs/feed.xml` from a Liquid template, advertised via `<link rel="alternate">`. A template rather than the `jekyll-feed` plugin deliberately avoids touching `Gemfile`/`Gemfile.lock` (lockfile regeneration needs local bundler, and CI installs with the frozen lockfile).
- `site.url` set to `https://documentdb.io` — required by `absolute_url` and the feed's permanent IDs.

## Validation

- The config's `defaults` apply `layout: default` to **every** file, so the feed explicitly sets `layout: null` — without this the XML would be wrapped in the HTML shell.
- Cover-image handling mirrors the exact `contains '://'` branch already used by `post-card.html` and `post.html`.
- The social card lives at the site root (outside the blog baseurl), so it's built from `site.url` directly; blog-relative cover images go through `absolute_url` (url + baseurl + path).
- CI's build-validation job runs the full Jekyll build and fails on any Liquid error. Pairs with #106, which sets the deployed baseurl to `/blogs` — **merge #106 first** so `og:url`/feed IDs don't carry the repo-name prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGMeNSmhAgmqzkdc7cQQgf