### PR TITLE
Refresh hardcoded GitHub stats on the AI page

### DIFF
--- a/app/ai/page.tsx
+++ b/app/ai/page.tsx
@@ -166,11 +166,11 @@ const useCases = [
 
 const credibilityPoints = [
   {
-    value: "3.2k+",
+    value: "3.4k+",
     label: "GitHub stars",
   },
   {
-    value: "200+",
+    value: "240+",
     label: "Forks",
   },
   {


### PR DESCRIPTION
## What

The /ai community section showed **3.2k+ stars / 200+ forks**; live values are **3,424 / 249** (GitHub API, 2026-07-30). Bumps to 3.4k+ / 240+.

Originally this PR also carried a homepage messaging rework (hero badges, press refresh, ecosystem section, FAQ) — dropped per review direction; only the stats refresh remains. The homepage still shows 3.2k+/200+ in its own community section; happy to bump that too or wire both to a build-time fetch so the numbers stop rotting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGMeNSmhAgmqzkdc7cQQgf