### PR TITLE
Fail the build when documentation content fails to compile

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -87,6 +87,26 @@ jobs:
         env:
           JEKYLL_BASE_PATH: /blogs
         run: npm run build
+      - name: Verify exported documentation pages
+        # A partially failed content compile must never reach production as a
+        # docs-less site. compile-content fails the build on clone/copy errors;
+        # this is the independent belt-and-braces check on the final artifact.
+        run: |
+          set -euo pipefail
+          for page in out/index.html out/docs/index.html out/docs/getting-started/index.html out/docs/reference/index.html; do
+            if [ ! -f "$page" ]; then
+              echo "Missing expected page: $page"
+              exit 1
+            fi
+          done
+          reference_count=$(find out/docs/reference -name index.html | wc -l)
+          echo "Reference pages exported: $reference_count"
+          # The docs repo currently holds ~240 reference entries; well under
+          # half of that means the compile silently lost content.
+          if [ "$reference_count" -lt 100 ]; then
+            echo "Only $reference_count reference pages exported - documentation content looks incomplete."
+            exit 1
+          fi
       - name: Download DocumentDB packages from latest release
         run: .github/scripts/download_packages.sh
       - name: Verify generated package components

--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,10 @@
 # Temporary content cloning directory
 _tmp/
 
-# Reference files
-api-reference/
-reference/
+# Reference files (compiled into the repo root from documentdb/docs; anchored
+# so the patterns cannot swallow tracked paths like app/docs/reference/)
+/api-reference/
+/reference/
 
 # Documentation articles
 articles/*/

--- a/scripts/compile-content.tsx
+++ b/scripts/compile-content.tsx
@@ -180,21 +180,44 @@ async function cloneContent(
       const repoName = source.repository.split('/').pop() || 'repo';
       const cloneDir = path.join(TEMP_DIR, repoName);
 
-      // Clone the repository
-      spawnSync(
+      // Clone the repository. A failed clone must fail the build: the copy
+      // loop below finds nothing to copy and the site would otherwise deploy
+      // with empty documentation and reference sections.
+      const cloneResult = spawnSync(
         'git',
         ['clone', '--depth', '1', '--branch', source.branch, source.repository, cloneDir],
         { stdio: 'pipe' }
       );
+
+      if (cloneResult.error) {
+        throw new Error(
+          `git clone failed for ${source.repository}: ${cloneResult.error.message}`
+        );
+      }
+
+      if (cloneResult.status !== 0) {
+        const stderr = cloneResult.stderr?.toString().trim();
+        throw new Error(
+          `git clone failed for ${source.repository} (branch ${source.branch}): ${stderr || `exit code ${cloneResult.status}`}`
+        );
+      }
 
       // Process each mapping
       for (const mapping of source.mappings) {
         const sourceDir = path.join(cloneDir, mapping.source);
         const targetDir = path.join(process.cwd(), mapping.target);
 
+        if (!fs.existsSync(sourceDir)) {
+          throw new Error(
+            `Source folder "${mapping.source}" does not exist in ${source.repository}; the repository layout may have changed.`
+          );
+        }
+
         // Clean target directory
         cleanDirectory(targetDir);
         ensureDirectory(targetDir);
+
+        const copiedBefore = tracker.getCopiedFiles().length;
 
         // Copy files with filtering
         copyFilesRecursive(
@@ -205,6 +228,12 @@ async function cloneContent(
           tracker,
           source.repository
         );
+
+        if (tracker.getCopiedFiles().length === copiedBefore) {
+          throw new Error(
+            `No files matched for mapping "${mapping.source}" -> "${mapping.target}" from ${source.repository}; refusing to build with empty documentation content.`
+          );
+        }
       }
     }
 


### PR DESCRIPTION
## Problem

`scripts/compile-content.tsx` runs `git clone` via `spawnSync` and **never checks the exit status**. If the `documentdb/docs` clone fails in CI (network blip, branch rename, repo move), `copyFilesRecursive` silently finds nothing to copy, the Next.js build succeeds, and the site **deploys with empty `/docs` and `/docs/reference` sections** — a total documentation outage with a green pipeline.

## Fix

Three layers, from cause to artifact:

1. **Clone failures fail the build** with git's stderr (both `spawnSync` error and non-zero exit paths). The throw flows into the script's existing error handling, which already exits 1.
2. **Mapping-level checks**: a source folder missing from the cloned repo (upstream layout change) or a mapping that matches zero files fails with a pointed message instead of shipping an empty section.
3. **Independent artifact check in the deploy workflow** before upload: key pages must exist in `out/`, and at least **100 reference pages** must have been exported — the docs repo currently holds ~240 reference entries (counted via the GitHub tree API), so the floor triggers only on genuine content loss while tolerating growth and reasonable shrinkage.

Also anchors the `api-reference/` and `reference/` gitignore patterns to the repo root — the unanchored form also matched `app/docs/reference/`, which breaks pathspecs against tracked files there.

## Validation

- Workflow YAML parsed locally.
- `git check-ignore -v` before/after: root `reference/foo.md` and `api-reference/foo.md` remain ignored; `app/docs/reference/page.tsx` is no longer matched by any ignore rule.
- The happy path (clone succeeds, content copies) is exercised by CI's full build on this PR; the failure paths reuse the script's existing catch → render error → exit 1 plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGMeNSmhAgmqzkdc7cQQgf