### PR TITLE
Fix sitemap: include the /packages page, exclude the exported 404 page

### DIFF
--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -12,15 +12,18 @@ const siteUrl = 'https://documentdb.io';
 const outDir = path.join(process.cwd(), 'out');
 
 // Top-level build outputs that are not HTML pages: Next.js assets, the APT/RPM
-// package repositories, release metadata, and images. The packages workflow
-// adds deb/, rpm/, and packages/ after this script runs in the deploy job, but
-// they are excluded here too so local full builds behave identically.
+// package repositories, images, and the not-found page (with trailingSlash the
+// export emits out/404/index.html alongside out/404.html). The packages
+// workflow adds deb/ and rpm/ after this script runs in the deploy job, but
+// they are excluded here too so local full builds behave identically. Note
+// that out/packages/ is NOT excluded: it is the exported /packages download
+// page; the workflow only adds release-info.json (not a page) next to it.
 const excludedTopLevelDirectories = new Set([
   '_next',
   'deb',
   'rpm',
-  'packages',
   'images',
+  '404',
 ]);
 
 function xmlEscape(value) {


### PR DESCRIPTION
## What

Post-deploy review of the first production sitemap (268 URLs at https://documentdb.io/sitemap.xml) found two defects in the generator, both introduced in #120:

1. **`/packages/` was missing** — the top-level `packages` exclusion was meant for the package-repository metadata the deploy workflow adds to `out/`, but the Next.js **/packages download page** also exports to `out/packages/index.html`. The workflow only ever adds `release-info.json` there (not a page), and only *after* the sitemap step has run, so the exclusion protected nothing and cost the sitemap one of the site's highest-intent pages.
2. **`/404/` was listed** — with `trailingSlash: true` the export emits `out/404/index.html` alongside `out/404.html`; the original mock test modeled only the file form, so the directory slipped through.

## Validation

Re-tested against a mock `out/` tree that now models the real export shape (`404/` directory, `packages/` page with `release-info.json` beside it, `deb/` repo dir with its own index.html): output contains `/packages/` and `/samples/`, and excludes `/404/` and `/deb/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGMeNSmhAgmqzkdc7cQQgf