### PR TITLE
Point the operator quick start links at the quick start

### DIFF
--- a/app/kubernetes-operator/page.tsx
+++ b/app/kubernetes-operator/page.tsx
@@ -1,7 +1,7 @@
 import CommandSnippet from "../components/CommandSnippet";
 import { getMetadata } from "../services/metadataService";
 import {
-  documentdbKubernetesOperatorDocsUrl,
+  documentdbKubernetesOperatorQuickStartUrl,
   documentdbKubernetesOperatorGitHubUrl,
 } from "../services/externalLinks";
 
@@ -278,7 +278,7 @@ export default function KubernetesOperatorPage() {
               </p>
               <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
                 <a
-                  href={documentdbKubernetesOperatorDocsUrl}
+                  href={documentdbKubernetesOperatorQuickStartUrl}
                   className="inline-flex w-full items-center justify-center rounded-md bg-emerald-500 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-emerald-400 sm:w-auto"
                 >
                   Open quick start
@@ -465,7 +465,7 @@ export default function KubernetesOperatorPage() {
                 </p>
               </div>
               <a
-                href={documentdbKubernetesOperatorDocsUrl}
+                href={documentdbKubernetesOperatorQuickStartUrl}
                 className="inline-flex items-center justify-center rounded-md bg-emerald-500 px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-emerald-400"
               >
                 Open quick start
@@ -489,7 +489,7 @@ export default function KubernetesOperatorPage() {
           </p>
           <div className="flex flex-col justify-center gap-3 sm:flex-row sm:flex-wrap">
             <a
-              href={documentdbKubernetesOperatorDocsUrl}
+              href={documentdbKubernetesOperatorQuickStartUrl}
               className="inline-flex w-full items-center justify-center rounded-md bg-emerald-500 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-emerald-400 sm:w-auto"
             >
               Open quick start

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import CommandSnippet from "./components/CommandSnippet";
-import { documentdbKubernetesOperatorDocsUrl } from "./services/externalLinks";
+import { documentdbKubernetesOperatorQuickStartUrl } from "./services/externalLinks";
 import { getMetadata } from "./services/metadataService";
 import { withBasePath } from "./services/sitePath";
 
@@ -549,7 +549,7 @@ export default function Home() {
                   Read operator overview
                 </Link>
                 <a
-                  href={documentdbKubernetesOperatorDocsUrl}
+                  href={documentdbKubernetesOperatorQuickStartUrl}
                   className="inline-flex items-center justify-center rounded-md border border-emerald-400/30 bg-emerald-500/10 px-6 py-3 text-sm font-semibold text-emerald-200 transition-colors hover:bg-emerald-500/20"
                 >
                   Open quick start

--- a/app/services/externalLinks.ts
+++ b/app/services/externalLinks.ts
@@ -1,7 +1,15 @@
 export const documentdbDiscordUrl = 'https://discord.gg/vH7bYu524D';
 
-export const documentdbKubernetesOperatorDocsUrl =
-  'https://documentdb.io/documentdb-kubernetes-operator/latest/preview/';
+// The operator docs are versioned as /<version-or-alias>/preview/..., where
+// `preview` is the content root inside a version, not a version itself. The
+// `latest` alias keeps this following operator releases.
+//
+// Every call site labels this link "Open quick start", so it points at the
+// quick start rather than the docs home. Linking the page directly also avoids
+// the redirect stubs at /documentdb-kubernetes-operator/ and .../latest/, which
+// are meta refreshes that only browsers follow.
+export const documentdbKubernetesOperatorQuickStartUrl =
+  'https://documentdb.io/documentdb-kubernetes-operator/latest/preview/getting-started/quickstart-kind/';
 
 export const documentdbKubernetesOperatorGitHubUrl =
   'https://github.com/documentdb/documentdb-kubernetes-operator';


### PR DESCRIPTION
## Summary

All four links labelled "Open quick start" — three on `/kubernetes-operator`, one on the home page — resolve to the operator's documentation home rather than to a quick start. The reader still has to find it from there.

This renames the constant for what every caller actually wants and points it at the kind quick start, the operator's canonical local walkthrough:

```
https://documentdb.io/documentdb-kubernetes-operator/latest/preview/getting-started/quickstart-kind/
-> 200 ("Quickstart: Kind - DocumentDB-Kubernetes-Operator")
```

Linking the page directly also skips the redirect stubs at `/documentdb-kubernetes-operator/` and `.../latest/`, which are meta refreshes that only browsers follow — fine for a human clicking through, not for anything that checks links.

No call site is left wanting the docs home, so the old export is gone rather than kept alongside the new one.

## Rebased

This branch originally also fixed the 404 itself — the constant was missing its version segment. #135 has since fixed that, so what remains here is only the retargeting, which #135 did not do.
