### PR TITLE
Fix the outbound build-from-source link that 404s

### DIFF
--- a/app/services/articleService.ts
+++ b/app/services/articleService.ts
@@ -274,7 +274,7 @@ If something does not work on the first try:
 ## Next steps
 
 - [Docker Quick Start](/docs/getting-started/docker)
-- [Building from source](https://github.com/documentdb/documentdb/blob/main/docs/v1/building.md)
+- [Building the packages from source](https://github.com/documentdb/documentdb/blob/main/packaging/README.md)
 - [Mongo Shell Quick Start](/docs/getting-started/mongo-shell-quickstart)
 - [Node.js Quick Start](/docs/getting-started/nodejs-setup)
 - [Python Quick Start](/docs/getting-started/python-setup)


### PR DESCRIPTION
## Summary

The packages quick start links to `docs/v1/building.md` in the engine repository, which no longer exists:

```
/documentdb/blob/main/docs/v1/building.md   -> 404
/documentdb/blob/main/packaging/README.md   -> 200
```

Build instructions for the packages live in `packaging/README.md` now, and the link text is adjusted to match what the target actually covers.

## Rebased

This branch originally carried a second fix, for the moved backup-and-restore link in the March operator blog post. #135 has since applied exactly that change, so the hunk is dropped rather than rebased — what remains is the part still needed.
