### PR TITLE
Hoist the GitHub stats into one shared constant

### DIFF
--- a/app/ai/page.tsx
+++ b/app/ai/page.tsx
@@ -2,6 +2,12 @@ import Image from "next/image";
 import Link from "next/link";
 import CommandSnippet from "../components/CommandSnippet";
 import { getMetadata } from "../services/metadataService";
+import {
+  documentdbGitHubForks,
+  documentdbGitHubStars,
+  documentdbTscMembers,
+  documentdbTscOrganizations,
+} from "../services/projectStats";
 import { withBasePath } from "../services/sitePath";
 
 export const metadata = getMetadata({
@@ -166,17 +172,17 @@ const useCases = [
 
 const credibilityPoints = [
   {
-    value: "3.4k+",
+    value: documentdbGitHubStars,
     label: "GitHub stars",
   },
   {
-    value: "240+",
+    value: documentdbGitHubForks,
     label: "Forks",
   },
   {
-    value: "11",
+    value: documentdbTscMembers,
     label: "TSC members",
-    detail: "across 5 organizations",
+    detail: `across ${documentdbTscOrganizations} organizations`,
   },
 ];
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,12 @@ import Link from "next/link";
 import CommandSnippet from "./components/CommandSnippet";
 import { documentdbKubernetesOperatorDocsUrl } from "./services/externalLinks";
 import { getMetadata } from "./services/metadataService";
+import {
+  documentdbGitHubForks,
+  documentdbGitHubStars,
+  documentdbTscMembers,
+  documentdbTscOrganizations,
+} from "./services/projectStats";
 import { withBasePath } from "./services/sitePath";
 
 export const metadata = getMetadata({
@@ -131,19 +137,19 @@ const trustBadges = [
 
 const credibilityPoints = [
   {
-    value: "3.2k+",
+    value: documentdbGitHubStars,
     label: "GitHub stars",
     detail: "on documentdb/documentdb",
   },
   {
-    value: "200+",
+    value: documentdbGitHubForks,
     label: "Public forks",
     detail: "public on GitHub",
   },
   {
-    value: "11",
+    value: documentdbTscMembers,
     label: "TSC members",
-    detail: "representing 5 organizations",
+    detail: `representing ${documentdbTscOrganizations} organizations`,
   },
 ];
 

--- a/app/services/projectStats.ts
+++ b/app/services/projectStats.ts
@@ -1,0 +1,19 @@
+// Single source for the upstream project figures quoted on marketing pages.
+// They were previously hardcoded independently on / and /ai, drifted apart,
+// and then went stale - a visitor moving between the two pages saw two
+// different star counts.
+//
+// Deliberately not fetched at build time: that would add a network dependency
+// (and a rate-limited, unauthenticated one) to every build. Refresh by hand:
+//
+//   curl -s https://api.github.com/repos/documentdb/documentdb \
+//     | jq '{stars: .stargazers_count, forks: .forks_count}'
+//
+// Last checked 2026-08-03: 3423 stars, 248 forks.
+export const documentdbGitHubStars = '3.4k+';
+export const documentdbGitHubForks = '240+';
+
+// From upstream MAINTAINERS.md: 11 members across Microsoft (4), Amazon (4),
+// AB InBev (1), Rippling (1), and YugabyteDB (1).
+export const documentdbTscMembers = '11';
+export const documentdbTscOrganizations = '5';


### PR DESCRIPTION
Addresses the second half of #128 (the GitHub stats). The `create_indexes_background` row in the first half is content in `documentdb/docs` and needs a separate PR there — see the note at the bottom.

## Problem

The star and fork counts were hardcoded independently in two files with no shared constant, so they drifted apart:

| Metric | `app/page.tsx` | `app/ai/page.tsx` | Actual |
| --- | --- | --- | --- |
| Stars | `3.2k+` | `3.4k+` | 3423 |
| Forks | `200+` | `240+` | 248 |

```
$ curl -s https://api.github.com/repos/documentdb/documentdb | jq "{stars: .stargazers_count, forks: .forks_count}"
{ "stars": 3423, "forks": 248 }
```

Both render in adjacent sections — "Built in the open" on `/` and "Built in the open, backed by a real ecosystem" on `/ai` — so a visitor moving between the two pages sees two different star counts for the same repository.

Worth being precise about severity: neither figure is *false*. The `+` suffix covers the actual numbers in both cases. The defect is that nothing stopped a refresh from updating one page and leaving the other behind, which is exactly what happened when #121 refreshed the AI page.

## Fix

Both pages now read from `app/services/projectStats.ts`. The TSC member and organization counts are hoisted too — they are quoted on both pages and currently agree, so this keeps them from being the next thing to drift. They were verified against upstream `MAINTAINERS.md`: 11 members across Microsoft (4), Amazon (4), AB InBev (1), Rippling (1), YugabyteDB (1).

Values stay hardcoded rather than fetched at build time, so the build keeps no network dependency on a rate-limited unauthenticated API. The refresh command and the date last checked are recorded in the file so the next update is a one-line change in one place.

No rendered output changes on `/ai`; `/` picks up the newer figures.

## Not in this PR

§1 of the issue — the `create_index_background` table row being wrong in name, schema, and description — lives in `postgres-api/functions.md` in `documentdb/docs`. `articles/` is a gitignored build artifact here, cloned at build time per `content.config.json`, so the fix cannot land in this repo. I confirmed the upstream definition while validating: `create_index_background--0.111-0.sql` defines `create_indexes_background` (plural) under `__API_SCHEMA_V2__`, which `Makefile:28` resolves to `documentdb_api`, not `documentdb_api_internal`. Happy to open that PR next.

npm is blocked on this machine, so lint and the build are left to CI. The change is a constant extraction with no logic.