### PR TITLE
Fix the Kubernetes operator links, install command, and missing content sync

### DIFF
--- a/app/kubernetes-operator/page.tsx
+++ b/app/kubernetes-operator/page.tsx
@@ -227,9 +227,8 @@ const bestFitScenarios = [
   "Operators that need failover, backup, promotion, and recovery workflows across clusters.",
 ] as const;
 
-const operatorQuickStartCommand = `helm repo add documentdb https://documentdb.github.io/documentdb-kubernetes-operator
-helm install documentdb-operator documentdb/documentdb-operator \\
-  --namespace documentdb-operator --create-namespace`;
+const operatorQuickStartCommand = `helm install documentdb-operator oci://ghcr.io/documentdb/documentdb-operator \\
+  --namespace documentdb-operator --create-namespace --wait`;
 
 export const metadata = getMetadata({
   title: "DocumentDB Kubernetes Operator",

--- a/app/services/externalLinks.ts
+++ b/app/services/externalLinks.ts
@@ -1,7 +1,7 @@
 export const documentdbDiscordUrl = 'https://discord.gg/vH7bYu524D';
 
 export const documentdbKubernetesOperatorDocsUrl =
-  'https://documentdb.io/documentdb-kubernetes-operator/preview/';
+  'https://documentdb.io/documentdb-kubernetes-operator/latest/preview/';
 
 export const documentdbKubernetesOperatorGitHubUrl =
   'https://github.com/documentdb/documentdb-kubernetes-operator';

--- a/articles/content.yml
+++ b/articles/content.yml
@@ -5,7 +5,7 @@ landing:
     - title: Getting Started with DocumentDB
       link: /docs/getting-started
     - title: DocumentDB Kubernetes Operator (Preview)
-      link: /kubernetes-operator
+      link: /docs/kubernetes-operator
     - title: API Reference
       link: /docs/reference
     - title: Postgres Extension API

--- a/blogs/_posts/2026-03-19-meet-documentdb-kubernetes-operator.md
+++ b/blogs/_posts/2026-03-19-meet-documentdb-kubernetes-operator.md
@@ -89,7 +89,7 @@ The public docs are clear that the operator is not yet recommended for productio
 
 - [GitHub repository](https://github.com/documentdb/documentdb-kubernetes-operator) — star the project, file issues, and contribute
 - [Quickstart guide](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/docs/operator-public-documentation/preview/index.md)
-- [Backup and restore guide](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/docs/operator-public-documentation/preview/backup-and-restore.md)
+- [Backup and restore guide](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/docs/operator-public-documentation/preview/operations/backup-and-restore.md)
 - [kubectl-documentdb plugin](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/docs/operator-public-documentation/preview/kubectl-plugin.md)
 - [TLS configuration guide](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/docs/operator-public-documentation/preview/configuration/tls.md)
 - [Multi-cloud deployment playground (AKS + GKE + EKS)](https://github.com/documentdb/documentdb-kubernetes-operator/blob/main/documentdb-playground/multi-cloud-deployment/README.md)

--- a/content.config.json
+++ b/content.config.json
@@ -23,6 +23,10 @@
         {
           "source": "documentdb-local",
           "target": "articles/documentdb-local"
+        },
+        {
+          "source": "kubernetes-operator",
+          "target": "articles/kubernetes-operator"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Every link we offer a reader who wants to learn about the Kubernetes operator is a 404, the install command we show them installs a four-month-old chart, and the docs section that just merged in documentdb/docs#62 never gets built at all.

## The section that does not build

`documentdb/docs#62` added a `kubernetes-operator` section. It is unreachable: `content.config.json` enumerates the folders copied out of the docs repository, so a section missing from that list is never copied, never exported, and 404s **permanently** rather than until the next deploy. `https://documentdb.io/docs/kubernetes-operator/` returns the not-found fallback right now. Added the mapping alongside the other four.

With the section building, the `/docs` landing entry for the operator now points at documentation rather than at this marketing page, which is what every other entry on that page does.

## The broken links

`documentdbKubernetesOperatorDocsUrl` is `https://documentdb.io/documentdb-kubernetes-operator/preview/`. The operator publishes its documentation under a version segment, so the working URL is `https://documentdb.io/documentdb-kubernetes-operator/latest/preview/`.

```
/documentdb-kubernetes-operator/preview/         -> 404 (GitHub Pages "Page not found")
/documentdb-kubernetes-operator/latest/preview/  -> 200 ("Home - DocumentDB-Kubernetes-Operator")
```

The constant is used in five places, so this is not a single dead link:

- `app/kubernetes-operator/page.tsx:282` — the page's primary call to action
- `app/kubernetes-operator/page.tsx:469`, `:493`
- `app/page.tsx:552` — the home page

## The stale install command

The operator page installs from the classic chart repository:

```sh
helm repo add documentdb https://documentdb.github.io/documentdb-kubernetes-operator
helm install documentdb-operator documentdb/documentdb-operator ...
```

That repository is still served, but its `index.yaml` tops out at **chart 0.2.0 / appVersion 0.2.0, published 2026-03-26**. The current chart is **0.3.0**, and the operator now publishes it as an OCI artifact, which is what its README and its own quickstarts use.

The version gap matters more than it looks: 0.3.0 is where the ImageVolume capability check and its admission webhook landed, so a reader who follows our page gets an operator that behaves differently from every guide they will read next. Replaced with the OCI install the operator documents.

## Also

The March operator blog post links to a backup and restore guide that has since moved under `preview/operations/`. Fixed in the same pass, since it was found by the same check.

## Verification

All URLs were checked against the live site, including the chart repository index. `content.config.json` parses.
