### PR TITLE
Close the gaps a four-distro cold install matrix found

### DIFF
--- a/PACKAGE-INSTALL.md
+++ b/PACKAGE-INSTALL.md
@@ -17,7 +17,13 @@ distribution has caught up to it yet, so the repository currently serves two sha
 - Both `amd64`/`x86_64` and `arm64`/`aarch64` variants are published.
 - The full stack is published for PostgreSQL **17** and **18**. The extension package alone is
   additionally available for PostgreSQL **16** on every distribution.
+- **PostgreSQL 16 is extension-only everywhere**, including Ubuntu 24.04 and RHEL 9: there is no
+  `documentdb-16`, and `postgresql-16-documentdb` is served at **0.114**, while 17/18 are at
+  0.116. Choosing PostgreSQL 16 therefore gives you no gateway and no `documentdb-setup`.
 - Debian 11 currently resolves PostgreSQL `16` and `17` only.
+- **Debian 13 only:** `apt.postgresql.org` also publishes DocumentDB for Trixie, and its version
+  string (`0.114-0-1.pgdg13+1`) outranks this repository's (`0.114-0`), so PGDG's build installs
+  by default.
 
 > On the extension-only distributions there is still no packaged gateway, setup helper, or
 > systemd service. To get a MongoDB-compatible endpoint there, follow
@@ -166,7 +172,18 @@ sudo systemctl stop    documentdb-local@18.target
 ```
 
 On hosts without systemd (containers, some dev images) the wizard starts the gateway directly
-instead; re-run `documentdb-setup` to restart it.
+instead; the `systemctl` commands above fail with *"System has not been booted with systemd"*.
+Use `documentdb-setup --status` to inspect it and re-run `documentdb-setup` to restart it.
+
+**Running SQL against the managed instance.** The private PostgreSQL instance is owned by the
+`documentdb-local` system user and listens on a socket, so a bare `psql` will not find it:
+
+```bash
+sudo -u documentdb-local psql -h /run/documentdb-local/18/postgresql -p 9718 -d postgres
+```
+
+Use that connection for the `ALTER EXTENSION` statements under Upgrading, and to read versions
+with `SELECT extname, extversion FROM pg_extension WHERE extname LIKE 'documentdb%';`.
 
 **Remove or reset:**
 

--- a/app/services/articleService.ts
+++ b/app/services/articleService.ts
@@ -116,21 +116,54 @@ Since v0.116-0 DocumentDB ships as a set of packages rather than a lone extensio
 
 | Package | Role |
 | --- | --- |
-| \`documentdb\` (meta) + \`documentdb-N\` | Full stand-alone install. Pins PostgreSQL major N and owns the systemd lifecycle. |
+| \`documentdb\` (meta) | Convenience package for the paved road — it simply depends on \`documentdb-18\`. |
+| \`documentdb-N\` | Full stand-alone install for PostgreSQL major N. Pulls in the extension, gateway, tools and \`documentdb-common\`, and owns the systemd lifecycle. |
 | \`postgresql-N-documentdb\` | The PostgreSQL extension itself (files only). |
 | \`documentdb-gateway\` | Wire-protocol runtime serving the MongoDB-compatible endpoint. |
 | \`documentdb-postgresql-tools\` | Admin helpers: \`documentdb-tune\`, \`documentdb-createcluster\`, \`documentdb-register-gateway\`, \`documentdb-gateway-admin\`. |
 | \`documentdb-common\` | Shared payload: \`documentdb-setup\`, the systemd units, helper scripts, sample data. |
 
-The full set is published for **Ubuntu 24.04** and **RHEL-compatible 9** on PostgreSQL 17 and 18. Ubuntu 22.04, Debian 11/12/13 and RHEL-compatible 8 still resolve the **extension package only** — for those, see [Extension-only hosts](#extension-only-hosts) below.
+> **The full stack is published for Ubuntu 24.04 and RHEL-compatible 9, on PostgreSQL 17 and 18 only.**
+>
+> **PostgreSQL 16 is extension-only everywhere**, including Ubuntu 24.04 and RHEL 9. There is no \`documentdb-16\` — asking for it fails with *"has no installation candidate"* (APT) or *"No match for argument"* (DNF). On PostgreSQL 16 you get \`postgresql-16-documentdb\` alone: no gateway, no \`documentdb-setup\`, no systemd units.
+>
+> Ubuntu 22.04, Debian 11/12/13 and RHEL-compatible 8 are extension-only on every major — see [Extension-only hosts](#extension-only-hosts).
+
+### Which version you get
+
+The repository serves the newest release that was actually built for your target, so the version differs by tier:
+
+| Target | Version served |
+| --- | --- |
+| Ubuntu 24.04 / RHEL 9 on PostgreSQL 17 or 18 | **0.116** (\`0.116-0\` on DEB, \`0.116.0-1.el9\` on RPM) |
+| PostgreSQL 16, any distribution | **0.114** |
+| Ubuntu 22.04, Debian 11/12/13, RHEL-compatible 8 | **0.114** |
+
+The examples below use the 0.116 strings. Substitute what your target serves — \`apt-cache madison <pkg>\` and \`dnf --showduplicates list <pkg>\` always show the truth.
 
 ## Choose the right package command
 
-Use the [Package Finder](/packages) to generate the exact install command for your distro, architecture, and PostgreSQL version.
+The [Package Finder](/packages) generates the command for any distro, architecture and PostgreSQL version. It needs JavaScript, so every combination is also written out below for scripted and headless installs.
 
 > The package commands assume a regular Linux host where you use \`sudo\`. In a clean container running as \`root\`, omit \`sudo\`.
 >
 > On Debian and Ubuntu in a clean container, also run \`export DEBIAN_FRONTEND=noninteractive\` first. Without it, \`tzdata\` prompts for input during \`apt install\` and the install hangs with no visible error.
+
+### The APT repository component and package for each target
+
+The DocumentDB APT repository is \`https://documentdb.io/deb stable <component>\`. Pick the component that matches your distribution:
+
+| Distribution | PGDG suite | DocumentDB component | Install |
+| --- | --- | --- | --- |
+| Ubuntu 24.04 | \`noble-pgdg\` | \`ubuntu24\` | \`documentdb-18\` or \`documentdb-17\` (full stack) |
+| Ubuntu 22.04 | \`jammy-pgdg\` | \`ubuntu22\` | \`postgresql-18-documentdb\` (extension only) |
+| Debian 11 | \`bullseye-pgdg\` | \`deb11\` | \`postgresql-17-documentdb\` (extension only; **PostgreSQL 18 is not installable here**) |
+| Debian 12 | \`bookworm-pgdg\` | \`deb12\` | \`postgresql-18-documentdb\` (extension only) |
+| Debian 13 | \`trixie-pgdg\` | \`deb13\` | \`postgresql-18-documentdb\` (extension only) |
+
+For RPM the repository is \`https://documentdb.io/rpm/rhel9\` or \`https://documentdb.io/rpm/rhel8\`. RHEL 9 installs \`documentdb-18\` / \`documentdb-17\` (full stack); RHEL 8 installs \`postgresql18-documentdb\` (extension only) and uses \`EL-8\` in the PGDG and EPEL URLs, with \`--set-enabled powertools\` instead of \`crb\`.
+
+> **Debian 13 only:** \`apt.postgresql.org\` also publishes DocumentDB extension packages for Trixie, and its version string (\`0.114-0-1.pgdg13+1\`) sorts above the one in this repository (\`0.114-0\`), so PGDG's build is what installs by default. It is a different build of the same release. Pin explicitly with \`apt install postgresql-18-documentdb=<VERSION>\` if you need this repository's copy.
 
 ## Install the packages
 
@@ -140,11 +173,17 @@ Use the [Package Finder](/packages) to generate the exact install command for yo
 ${buildAptInstallCommand('ubuntu24', 'amd64', '18')}
 \`\`\`
 
+For PostgreSQL 17 on the same host, install \`documentdb-17\` instead of \`documentdb-18\`. The \`documentdb\` meta package is equivalent to \`documentdb-18\`.
+
 ### RPM example (RHEL-compatible 9, PostgreSQL 18)
 
 \`\`\`bash
 ${buildRpmInstallCommand('rhel9', 'x86_64', '18')}
 \`\`\`
+
+For PostgreSQL 17, install \`documentdb-17\`. The \`documentdb\` meta package is equivalent to \`documentdb-18\`.
+
+> **Why the \`crb\` line matters.** DocumentDB's extension depends on PostGIS, which pulls in \`gdal*-libs\`, which needs \`libqhull_r.so.7\` — and that library ships only in **CRB** (CodeReady Builder; \`powertools\` on EL8). If CRB is not enabled, \`dnf install\` fails with dozens of lines like \`nothing provides libqhull_r.so.7()(64bit) needed by gdal313-libs\`, naming GDAL but never the missing repository. Do not drop that line.
 
 ## Set up and connect
 
@@ -213,7 +252,21 @@ sudo systemctl restart documentdb-local@18.target
 sudo systemctl stop    documentdb-local@18.target
 \`\`\`
 
-On hosts without systemd the wizard starts the gateway directly; re-run \`documentdb-setup\` to restart it.
+**On hosts without systemd** — containers and some dev images — the wizard says so at the end of setup and starts the gateway directly instead. The \`systemctl\` commands above will fail with *"System has not been booted with systemd"*; use \`documentdb-setup --status\` to inspect it and re-run \`documentdb-setup\` to restart it. \`documentdb-setup --restore\` stops the directly-started gateway for you.
+
+### Running SQL against the managed instance
+
+\`documentdb-setup\` creates a private PostgreSQL instance owned by the \`documentdb-local\` system user, listening on a socket rather than TCP, so a bare \`psql\` will not find it. Connect as that user through the per-major socket directory:
+
+\`\`\`bash
+sudo -u documentdb-local psql -h /run/documentdb-local/18/postgresql -p 9718 -d postgres
+\`\`\`
+
+That is the connection to use for the \`ALTER EXTENSION\` statements under [Upgrading](#upgrading), and to read the installed versions:
+
+\`\`\`sql
+SELECT extname, extversion FROM pg_extension WHERE extname LIKE 'documentdb%';
+\`\`\`
 
 Remove or reset:
 
@@ -248,7 +301,9 @@ PostgreSQL applies intermediate upgrade scripts automatically. In-place upgrades
 
 ## Extension-only hosts
 
-Ubuntu 22.04, Debian 11/12/13 and RHEL-compatible 8 currently serve the extension package alone — no gateway, setup helper, or systemd units. On those hosts the install command ends in \`postgresql-<PG>-documentdb\` (APT) or \`postgresql<PG>-documentdb\` (RPM), and there is no \`documentdb-setup\`.
+Ubuntu 22.04, Debian 11/12/13 and RHEL-compatible 8 serve the extension package alone — no gateway, setup helper, or systemd units — and so does **PostgreSQL 16 on every distribution**. On those targets the install command ends in \`postgresql-<PG>-documentdb\` (APT) or \`postgresql<PG>-documentdb\` (RPM), there is no \`documentdb-setup\`, and the version served is 0.114. See the component and package table under [Choose the right package command](#choose-the-right-package-command) for the exact repository line per distribution.
+
+**Debian 11 does not support PostgreSQL 18.** \`apt install postgresql-18-documentdb\` there fails with \`Depends: postgresql-18-postgis-3 but it is not installable\` — the upstream Bullseye PostGIS build does not exist. Use PostgreSQL 16 or 17.
 
 Confirm the extension landed with package metadata:
 


### PR DESCRIPTION
## How this was found

Four testers with **no prior DocumentDB knowledge** installed from the **live site** using the **real** `documentdb.io` repository, in Docker, across the whole support matrix:

| Tester | Coverage | Score |
|---|---|---|
| A | Ubuntu 24.04 full stack — meta + PG17 | 4/5 |
| B | RHEL 9 full stack — meta + PG17, **deliberately skipping CRB** | 3/5 |
| C | Ubuntu 22.04, Debian 11/12/13 | 3/5 |
| D | RHEL 8, and **PostgreSQL 16 on the paved road** | 2.5/5 |

**Every runtime claim the site makes held up** — the `0.0.0.0:10260` gateway vs `127.0.0.1:9700+N` PostgreSQL split, log and config paths, the no-systemd `nohup` fallback, and the corrected uninstall. Both full-stack paths reached an inserted-and-queried document. The failures were entirely in what the pages say.

## What they found, and what this changes

**1. Static install commands existed for two distributions out of seven.** Three testers independently hit this. Everything except Ubuntu 24.04 and RHEL 9 lives behind the JavaScript Package Finder — invisible to `curl`, which is exactly the headless audience a Linux packages page serves. Testers *guessed* `ubuntu22`, `deb11`, `deb12`, `rhel8` from the two worked examples. They guessed right; that is luck. Adds a component-and-package table for every distribution.

**2. PostgreSQL 16 on the paved road silently double-downgrades.** `documentdb-16` does not exist, so the advertised full stack degrades to a bare extension, *and* `postgresql-16-documentdb` is served at **0.114** while 17/18 are at **0.116** in the same repository. Nothing said so, and every version example on the page read 0.116. Now stated inline, plus a which-version-per-tier table.

**3. The CRB line had a command but no reason.** With CRB disabled, tester B reproduced the failure exactly — **76 lines** of GDAL candidates and `nothing provides libqhull_r.so.7`, which names GDAL but never the missing repository. The chain is now explained so nobody trims that line as noise.

**4. The `documentdb` meta package was named but never explained.** It depends on `documentdb-18`; testers learned that from `apt-cache depends`, not from us.

**5. No way to reach the managed PostgreSQL was documented** — despite Upgrading instructing `ALTER EXTENSION`. It is peer auth as `documentdb-local` over a per-major socket; two testers failed at this before reverse-engineering it. Now documented and verified:

\\\
sudo -u documentdb-local psql -h /run/documentdb-local/18/postgresql -p 9718 -d postgres
  documentdb_extended_rum | 0.116-0
  documentdb_core         | 0.116-0
  documentdb              | 0.116-0
\\\

**6. Debian 13 does not install from this repository.** `apt.postgresql.org` also ships DocumentDB for Trixie, and its `0.114-0-1.pgdg13+1` outranks our `0.114-0`. I verified the scope: PGDG carries DocumentDB for **trixie only** — bullseye, bookworm, jammy and noble have zero. Now documented, with how to pin.

**7. Debian 11 / PostgreSQL 18** moved out of the troubleshooting footer — that is where a newcomer picking "newest" lands. The site's prediction was verified correct: `Depends: postgresql-18-postgis-3 but it is not installable`.

## Validation

130 tests, `tsc --noEmit`, and `next build` all pass; every new string verified present in the rendered guide.

Claims tested against reality rather than assumed — the CRB failure mode, the Debian 11 exclusion, the PGDG overlap, the meta's dependency, and the psql route were each executed in a container.