### PR TITLE
Make the Download page agree with the repository

### DIFF
--- a/app/packages/page.tsx
+++ b/app/packages/page.tsx
@@ -438,52 +438,89 @@ export default function PackagesPage() {
                     <th className="px-3 py-2 font-semibold">Architectures</th>
                     <th className="px-3 py-2 font-semibold">PostgreSQL versions</th>
                     <th className="px-3 py-2 font-semibold">Package naming</th>
+                    <th className="px-3 py-2 font-semibold">Version served</th>
                   </tr>
                 </thead>
                 <tbody className="text-gray-300">
                   <tr className="border-b border-neutral-800">
                     <td className="px-3 py-3 font-semibold text-blue-300">APT</td>
-                    <td className="px-3 py-3">Ubuntu 24.04 (full stack)</td>
+                    <td className="px-3 py-3">Ubuntu 24.04 (full stack) · <code className="text-gray-200">ubuntu24</code></td>
                     <td className="px-3 py-3">amd64, arm64</td>
                     <td className="px-3 py-3">17, 18</td>
                     <td className="px-3 py-3">
                       <code className="text-gray-200">documentdb-&lt;pg&gt;</code>
                     </td>
+                    <td className="px-3 py-3">0.116</td>
                   </tr>
                   <tr className="border-b border-neutral-800">
                     <td className="px-3 py-3 font-semibold text-blue-300">APT</td>
-                    <td className="px-3 py-3">Ubuntu 22.04, Debian 11/12/13 (extension only)</td>
+                    <td className="px-3 py-3">Ubuntu 24.04 (extension only) · <code className="text-gray-200">ubuntu24</code></td>
+                    <td className="px-3 py-3">amd64, arm64</td>
+                    <td className="px-3 py-3">16</td>
+                    <td className="px-3 py-3">
+                      <code className="text-gray-200">postgresql-16-documentdb</code>
+                    </td>
+                    <td className="px-3 py-3">0.114</td>
+                  </tr>
+                  <tr className="border-b border-neutral-800">
+                    <td className="px-3 py-3 font-semibold text-blue-300">APT</td>
+                    <td className="px-3 py-3">Ubuntu 22.04 · <code className="text-gray-200">ubuntu22</code><br />Debian 11/12/13 · <code className="text-gray-200">deb11</code> / <code className="text-gray-200">deb12</code> / <code className="text-gray-200">deb13</code><br />(extension only)</td>
                     <td className="px-3 py-3">amd64, arm64</td>
                     <td className="px-3 py-3">16, 17, 18 (Debian 11: 16, 17)</td>
                     <td className="px-3 py-3">
                       <code className="text-gray-200">postgresql-&lt;pg&gt;-documentdb</code>
                     </td>
+                    <td className="px-3 py-3">0.114</td>
                   </tr>
                   <tr className="border-b border-neutral-800">
                     <td className="px-3 py-3 font-semibold text-red-300">RPM</td>
-                    <td className="px-3 py-3">RHEL-compatible 9 (full stack)</td>
+                    <td className="px-3 py-3">RHEL-compatible 9 (full stack) · <code className="text-gray-200">rpm/rhel9</code></td>
                     <td className="px-3 py-3">x86_64, aarch64</td>
                     <td className="px-3 py-3">17, 18</td>
                     <td className="px-3 py-3">
                       <code className="text-gray-200">documentdb-&lt;pg&gt;</code>
                     </td>
+                    <td className="px-3 py-3">0.116</td>
+                  </tr>
+                  <tr className="border-b border-neutral-800">
+                    <td className="px-3 py-3 font-semibold text-red-300">RPM</td>
+                    <td className="px-3 py-3">RHEL-compatible 9 (extension only) · <code className="text-gray-200">rpm/rhel9</code></td>
+                    <td className="px-3 py-3">x86_64, aarch64</td>
+                    <td className="px-3 py-3">16</td>
+                    <td className="px-3 py-3">
+                      <code className="text-gray-200">postgresql16-documentdb</code>
+                    </td>
+                    <td className="px-3 py-3">0.114</td>
                   </tr>
                   <tr>
                     <td className="px-3 py-3 font-semibold text-red-300">RPM</td>
                     <td className="px-3 py-3">
-                       RHEL-compatible 8 (extension only, tested on Rocky Linux)
+                       RHEL-compatible 8 (extension only, tested on Rocky Linux) · <code className="text-gray-200">rpm/rhel8</code>
                     </td>
                     <td className="px-3 py-3">x86_64, aarch64</td>
                     <td className="px-3 py-3">16, 17, 18</td>
                     <td className="px-3 py-3">
                       <code className="text-gray-200">postgresql&lt;pg&gt;-documentdb</code>
                     </td>
+                    <td className="px-3 py-3">0.114</td>
                   </tr>
                 </tbody>
               </table>
+              <p className="mt-3 text-xs text-amber-300">
+                <strong>PostgreSQL 16 is extension-only on every distribution</strong>, including
+                Ubuntu 24.04 and RHEL 9. There is no <code>documentdb-16</code> — requesting it
+                fails with <em>&quot;has no installation candidate&quot;</em> (APT) or{" "}
+                <em>&quot;No match for argument&quot;</em> (DNF). On PostgreSQL 16 you get the
+                extension alone, at 0.114: no gateway, no <code>documentdb-setup</code>, no
+                systemd units. The packaged stack requires PostgreSQL 17 or 18.
+              </p>
               <p className="mt-3 text-xs text-gray-400">
                 Use Package Finder above to generate the exact command for your selected
-                target instead of scanning all combinations manually.
+                target, or see the{" "}
+                <Link href="/docs/getting-started/packages" className="text-blue-400 hover:text-blue-300">
+                  Linux Packages Quick Start
+                </Link>{" "}
+                for every repository component and install command written out in full.
               </p>
               <p className="mt-2 text-xs text-gray-500">
                 Debian 13 packages are available in the <code>deb13</code> APT component and


### PR DESCRIPTION
## Why

A confirmation round of cold installs (terminal-only testers, live site, real repository, Docker) found the **docs guide now matches reality exactly**:

- One tester wrote down what it expected for PostgreSQL 16 *before* installing and hit it verbatim — package name, `0.114-0`, the absent `documentdb-setup`, and even the literal `has no installation candidate` error for `documentdb-16`.
- Another installed on Ubuntu 22.04, Debian 11, Debian 12 and Rocky 8 and reported **"Nothing was guessed"** — every value traced to a site string. The Debian 11 / PostgreSQL 18 prediction matched to the exact dependency error.

The remaining gap is that **`/packages` — the page people land on — disagreed with the guide.**

## What was wrong

**1. The catalog said PostgreSQL 16 was unavailable on the paved road.** It listed 16 only under the extension-only distributions, so Ubuntu 24.04 and RHEL 9 appeared to be 17/18-only. In reality `postgresql-16-documentdb` installs there fine — as the extension alone, at **0.114** rather than 0.116. A reader of only this page would conclude they had to leave Ubuntu 24.04 to use PostgreSQL 16.

**2. No version was shown**, while every example string on the page reads 0.116 — so the 0.114 tiers were invisible.

**3. Only the `deb13` component was named.** A terminal user who never reached the guide had no component for their distribution and no JavaScript to generate one.

## Changes

- Added the two missing PostgreSQL 16 rows (Ubuntu 24.04, RHEL 9), marked extension-only.
- Added a **Version served** column: 0.116 for the full-stack tiers, 0.114 for the rest.
- Carried the **no-`documentdb-16`** warning onto the page, with both package managers' error text.
- Put the **repository component** on every row (`ubuntu24`, `ubuntu22`, `deb11`/`deb12`/`deb13`, `rpm/rhel9`, `rpm/rhel8`).
- Footnote now links to the Linux Packages Quick Start for the full commands.

## Validation

130 tests, `tsc --noEmit`, `eslint` and `next build` all pass. Every added string verified present in the rendered page, including all seven component names.