### PR TITLE
Fix air-gapped install blockers found by a cold-start test of the published page

### DIFF
--- a/app/services/articleService.ts
+++ b/app/services/articleService.ts
@@ -133,7 +133,7 @@ ${buildRpmInstallCommand('rhel9', 'x86_64', '18')}
 For PostgreSQL 17, install \`documentdb-17\`; the \`documentdb\` meta package is equivalent to \`documentdb-18\`. For any other distribution, architecture or major, use the [Package Finder](/packages).
 
 > [!NOTE]
-> In a container running as \`root\`, drop \`sudo\`. On Debian/Ubuntu also \`export DEBIAN_FRONTEND=noninteractive\` first, or \`tzdata\` prompts and the install hangs with no visible error.
+> In a container running as \`root\`, drop the leading \`sudo\` (it is often not installed). Leave \`sudo -u <user>\` commands alone — those switch user rather than elevate; run them as \`su <user> -c '...'\` instead. On Debian/Ubuntu also \`export DEBIAN_FRONTEND=noninteractive\` first, or \`tzdata\` prompts and the install hangs with no visible error.
 
 > [!WARNING]
 > **On ARM, change three strings** — the commands above are written for x86_64.
@@ -174,10 +174,10 @@ printf '%s\\n' '[mongodb-org-8.0]' 'name=MongoDB Repository' \\
 sudo dnf install -y mongodb-mongosh
 \`\`\`
 
-Then connect. Passing credentials as flags avoids URI escaping entirely:
+Then connect. A bare \`-p\` makes \`mongosh\` **prompt** for the password, so pass it inline in scripts and CI — otherwise a non-interactive shell sends an empty password and fails with the unhelpful \`MongoServerError: Invalid key\`:
 
 \`\`\`bash
-mongosh localhost:10260 -u admin -p --authenticationMechanism SCRAM-SHA-256 \\
+mongosh localhost:10260 -u admin -p '<PASSWORD>' --authenticationMechanism SCRAM-SHA-256 \\
         --tls --tlsAllowInvalidCertificates --eval 'db.runCommand({ping: 1})'
 \`\`\`
 
@@ -232,6 +232,9 @@ sudo systemctl stop    documentdb-local@18.target
 \`\`\`
 
 **Without systemd** (containers, some dev images) the wizard starts the gateway directly and says so. \`systemctl\` will fail with *"System has not been booted with systemd"* — use \`documentdb-setup --status\` to inspect, re-run \`documentdb-setup\` to restart, \`--restore\` to stop.
+
+> [!NOTE]
+> On a **minimal RHEL-compatible image, install \`procps-ng\` first**. \`documentdb-setup\` locates the directly-started gateway with \`pgrep\`; without it \`--restore\` reports success while the gateway keeps serving, and a later re-run then fails with \`Port 10260 is already in use\`. Debian and Ubuntu images already ship \`procps\`.
 
 ### Running SQL against the managed instance
 
@@ -310,10 +313,11 @@ An air-gapped host has no route to PGDG either, and DocumentDB pulls PostgreSQL,
 
 ### Stage the bundle (connected machine)
 
-With the same repositories configured as for an online install:
+With the same repositories configured as for an online install — run the [Install](#install) command for your distribution **up to and including \`apt update\` / the \`dnf config-manager\` line, but not the final \`install\`**:
 
 \`\`\`bash
 # Debian / Ubuntu
+sudo apt-get install -y dpkg-dev
 mapfile -t PKGS < <(apt-cache depends --recurse --no-recommends --no-suggests \\
     --no-conflicts --no-breaks --no-replaces --no-enhances documentdb-18 \\
   | grep '^[a-zA-Z0-9]' | sort -u)
@@ -337,14 +341,14 @@ Expect ~200 packages / 200 MB (DEB) or ~270 / 170 MB (RPM), mostly PostGIS and G
 
 ### Install from the bundle (air-gapped target)
 
-Copy \`bundle/\` across and point the package manager at it — the local index restores full dependency resolution:
+Copy \`bundle/\` across — including the \`Packages\`/\`Packages.gz\` or \`repodata/\` index inside it, which is what makes the next step resolve — and point the package manager at it:
 
 \`\`\`bash
 # Debian / Ubuntu
-echo "deb [trusted=yes] file:/path/to/bundle ./" \\
+echo "deb [trusted=yes] file:///path/to/bundle ./" \\
   | sudo tee /etc/apt/sources.list.d/documentdb-offline.list
 sudo apt-get update
-sudo apt install documentdb-18
+sudo apt install -y documentdb-18
 \`\`\`
 
 \`\`\`bash
@@ -352,8 +356,11 @@ sudo apt install documentdb-18
 printf '%s\\n' '[documentdb-offline]' 'name=DocumentDB offline bundle' \\
   'baseurl=file:///path/to/bundle' 'enabled=1' 'gpgcheck=0' \\
   | sudo tee /etc/yum.repos.d/documentdb-offline.repo
-sudo dnf install documentdb-18
+sudo dnf install -y --disablerepo='*' --enablerepo=documentdb-offline documentdb-18
 \`\`\`
+
+> [!IMPORTANT]
+> The \`--disablerepo\`/\`--enablerepo\` pair is not optional. DNF **aborts the whole transaction** if any enabled repository is unreachable, and every RHEL-compatible image ships \`baseos\`, \`appstream\` and \`extras\` enabled — so without it the install fails with \`Error: Failed to download metadata for repo 'baseos'\` even though your bundle is perfectly good. APT differs here: it only warns about unreachable sources and continues.
 
 \`[trusted=yes]\` / \`gpgcheck=0\` accept the unsigned local directory. Upstream signatures were verified at staging time; \`sha256sum\` the transfer if it crosses an untrusted boundary.
 
@@ -361,7 +368,7 @@ Then continue with **Set up and connect** above — \`documentdb-setup\` needs n
 
 ### Smaller offline cases
 
-If the target already has PostgreSQL and the PGDG extension dependencies (\`postgresql-N-cron\`, \`-pgvector\`, \`-postgis-3\`), you do not need a bundle:
+If the target already has PostgreSQL, the PGDG extension dependencies (\`postgresql-N-cron\`, \`-pgvector\`, \`-postgis-3\`) and \`jq\`, you do not need a bundle:
 
 - **Extension only, one file** — \`sudo apt install ./ubuntu24.04-postgresql-18-documentdb_0.116-0_amd64.deb\`. No gateway and no \`documentdb-setup\`.
 - **Full stack from the release assets** — pass all six files for your platform to a *single* \`apt install\` / \`dnf install\`. Local files resolve dependencies only against enabled repositories, so the meta package on its own fails with \`Depends: documentdb-18 ... but it is not installable\`.


### PR DESCRIPTION
Two testers followed https://documentdb.io/docs/getting-started/packages/ **verbatim** in containers with no prior knowledge of DocumentDB. Results split sharply:

| Path | Verdict |
|---|---|
| Online (APT + RPM → wizard → mongosh) | ✅ worked **first try on both distros**, zero errors |
| Air-gapped | ❌ **could not be completed on either path** |

Every fix below is from an observed failure, not review.

---

## 1. DEB staging silently produces a broken bundle

`dpkg-scanpackages` lives in `dpkg-dev`, which is **not** in `ubuntu:24.04`. The string `dpkg-dev` appeared **zero times** on the page.

```
dpkg-scanpackages . /dev/null > Packages && gzip -k Packages
/w/stage_deb.sh: line 50: dpkg-scanpackages: command not found      # exit 127
```

This is worse than a normal failure because it fails **silently**. The `>` redirection still creates the file and `&&` short-circuits before `gzip`, so the bundle ends up with a 0-byte `Packages` and no `Packages.gz` — right after 205 successful downloads printed:

```
DEB_COUNT=205   BUNDLE_SIZE=203M
-rw-r--r-- 1 root root  0  Packages
ls: cannot access 'Packages.gz': No such file or directory
```

On the target, `apt-get update` then **exits 0** (the only clue is `Err:7 ... Method gave a blank filename`, buried among expected offline warnings), and the install dies an hour and 200 MB later:

```
E: Unable to locate package documentdb-18        # exit 100
```

**Fix:** install `dpkg-dev` first — mirroring the RPM block, which already installs `createrepo_c`.

## 2. RPM air-gapped install aborts on the target's stock repos

DNF aborts the **whole transaction** if any enabled repository is unreachable, and every RHEL-compatible image ships `baseos`, `appstream`, `extras` enabled. The bundle was read fine (`341 kB` of metadata) and the install still failed:

```
Error: Failed to download metadata for repo 'baseos': Cannot prepare internal mirrorlist  # exit 1
```

`--disablerepo` / `--enablerepo` appeared **zero times** on the page. With them added, the bundle proved complete: `Install 164 Packages / Upgrade 2 / 118 M / Complete!`

**Fix:** add the flags and explain the asymmetry — APT only *warns* about unreachable sources and continues; DNF aborts.

## 3. Offline installs lacked `-y`

The online blocks have it, the offline ones didn't, so both aborted at the prompt in a container — on a page that explicitly caters to containers. Note `DEBIAN_FRONTEND=noninteractive` does **not** answer apt's continue prompt.

## 4. `jq` missing from the "no bundle needed" preconditions

Built exactly the documented precondition, offline, then installed the files:

```
documentdb-common : Depends: jq but it is not installable
documentdb-postgresql-tools : Depends: jq but it is not installable    # exit 100
```

`jq` appeared **zero times** on the page. Adding it to the precondition → exit 0. On an air-gapped host `jq` cannot be resolved from anywhere, so this case did not work as written.

## 5. Two traps outside the offline section

- **`sudo -u documentdb-local psql`** collides with the blanket *"in a container, drop `sudo`"*. Applied literally that gives `-u documentdb-local psql` → `bash: - : invalid option`. `sudo -u` switches user rather than elevates; now called out.
- **`mongosh ... -u admin -p`** — a bare `-p` **prompts**. Non-interactive, that sends an empty password and fails with `MongoServerError: Invalid key`, which names neither auth nor the empty credential. This form was introduced by my own earlier change and is now inline.

## 6. `--restore` claim is distro-dependent

The page said `--restore` stops the gateway on non-systemd hosts. I tested both:

| | Result |
|---|---|
| `ubuntu:24.04` | ✅ `Stopping orphan (non-systemd) gateway daemon (pid 7770)` → port **DOWN** |
| `rockylinux:9` | ❌ reports success, gateway **keeps serving authenticated traffic** |

Root cause is in `documentdb-setup`:

```bash
for _pid in $(pgrep -f /usr/lib/documentdb-gateway/documentdb-gateway-daemon 2>/dev/null); do
```

Without `pgrep` the loop runs **zero times** and the function silently succeeds; `2>/dev/null` swallows the `command not found`. Ubuntu ships `procps`; minimal RHEL images do not. The downstream symptom is the *next* failure too — a later re-run hits `Port 10260 is already in use`.

This page now documents the prerequisite, but **the real fix is packaging**: `documentdb-common` declares neither `procps-ng` (RPM) nor `procps` (DEB). Reported separately against `documentdb/documentdb`; this PR only stops the page from asserting something that is false on RHEL.

---

## Verification

Every changed command re-run verbatim. Staging on a connected container, installing into one started with `--network none` (air-gap proven by DNS failure before each install):

| Path | Observed |
|---|---|
| DEB bundle | 205 pkgs / 203 MB → `Need to get 0 B/95.2 MB` → **exit 0** |
| RPM bundle | 271 pkgs / 173 MB → `Install 164 / Upgrade 2` → **exit 0** |
| Extension-only, one file | **exit 0** |
| `--restore` on ubuntu:24.04 | **exit 0**, port down |

The page's stated sizes were accurate — *"~200 packages / 200 MB (DEB) or ~270 / 170 MB (RPM)"* vs observed 205/203 MB and 271/173 MB.

`npm test` 130 passed · `eslint` clean · `tsc --noEmit` clean.

## Related

documentdb/docs#70 — same `mongosh -p` fix on the docs-repo page.
