### PR TITLE
Fix broken commands and false claims in the connect guides

### DIFF
--- a/app/services/articleService.ts
+++ b/app/services/articleService.ts
@@ -30,7 +30,7 @@ Then start the container:
 
 \`\`\`bash
 docker run -dt --name documentdb \\
-  -p 10260:10260 \\
+  -p 127.0.0.1:10260:10260 \\
   ghcr.io/documentdb/documentdb/documentdb-local:latest \\
   --username <YOUR_USERNAME> \\
   --password <YOUR_PASSWORD> \\
@@ -38,6 +38,9 @@ docker run -dt --name documentdb \\
 \`\`\`
 
 > Replace \`<YOUR_USERNAME>\` and \`<YOUR_PASSWORD>\` with your own credentials.
+>
+> \`-p 127.0.0.1:10260:10260\` keeps the endpoint on loopback. A bare \`-p 10260:10260\`
+> publishes it on **every** interface, which is rarely what you want on a laptop.
 >
 > \`--init-data true\` seeds the built-in sample data into \`sampledb\`, which the
 > verification step below queries. It is **not** enabled by default — without it the
@@ -54,6 +57,14 @@ docker ps --filter "name=documentdb"
 
 You should see the container in an \`Up\` state with port \`10260\` published.
 
+> [!IMPORTANT]
+> \`docker ps\` reports \`Up\` well before DocumentDB accepts connections. Wait for the
+> readiness banner, or the first \`mongosh\` call fails with a connection error:
+>
+> \`\`\`bash
+> until docker logs documentdb 2>&1 | grep -q "=== DocumentDB is ready ==="; do sleep 2; done
+> \`\`\`
+
 ## Verify the connection
 
 Use \`mongosh\` to confirm authentication, TLS, and the gateway endpoint are working:
@@ -67,14 +78,14 @@ mongosh localhost:10260 \\
   --tlsAllowInvalidCertificates
 \`\`\`
 
-Then run a quick health check and inspect the built-in sample data:
+Then run a quick health check. The sample data below needs \`--init-data true\` on the \`docker run\` above — without it \`sampledb\` does not exist:
 
 \`\`\`javascript
 db.runCommand({ ping: 1 })
 
 use sampledb
 
-db.users.find({}, { name: 1, email: 1, _id: 0 }).limit(3)
+db.users.find({}, { firstName: 1, lastName: 1, email: 1, _id: 0 }).limit(3)
 \`\`\`
 
 If you prefer certificate validation instead of \`--tlsAllowInvalidCertificates\`, follow the certificate steps in [DocumentDB Local](/docs/documentdb-local).
@@ -88,6 +99,28 @@ The quick start command above is ideal for disposable local environments. When y
 - Use \`--init-data-path\` to run your own \`.js\` initialization scripts with \`mongosh\` at startup
 
 The built-in sample dataset includes \`users\`, \`products\`, \`orders\`, and \`analytics\` collections in \`sampledb\`.
+
+## Stop, start, and remove
+
+\`\`\`bash
+docker stop documentdb       # stop, keep the data
+docker start documentdb      # bring it back later
+docker restart documentdb
+docker logs documentdb       # gateway and startup output
+\`\`\`
+
+To update the image or start over:
+
+\`\`\`bash
+# DESTROYS the container and its anonymous data volume
+docker rm -fv documentdb
+docker pull ghcr.io/documentdb/documentdb/documentdb-local:latest
+# then run the Start DocumentDB command again
+\`\`\`
+
+Until you remove it, re-running \`docker run --name documentdb\` fails with
+\`Conflict. The container name "/documentdb" is already in use\`. Mount a named volume
+(\`-v documentdb-data:/data\`) before storing anything you want to keep.
 
 ## Troubleshooting and debugging
 
@@ -169,7 +202,7 @@ sudo apt update && sudo apt install -y mongodb-mongosh
 
 # RHEL-compatible 9
 printf '%s\\n' '[mongodb-org-8.0]' 'name=MongoDB Repository' \\
-  'baseurl=https://repo.mongodb.org/yum/redhat/9/mongodb-org/8.0/x86_64/' \\
+  "baseurl=https://repo.mongodb.org/yum/redhat/9/mongodb-org/8.0/$(uname -m)/" \\
   'gpgcheck=1' 'enabled=1' 'gpgkey=https://pgp.mongodb.com/server-8.0.asc' | sudo tee /etc/yum.repos.d/mongodb-org-8.0.repo >/dev/null
 sudo dnf install -y mongodb-mongosh
 \`\`\`
@@ -593,7 +626,7 @@ If you want certificate validation instead of \`tlsAllowInvalidCertificates=true
 copy the generated certificate from the container and point the driver at it.
 
 \`\`\`bash
-docker cp documentdb:/home/documentdb/gateway/pg_documentdb_gw/cert.pem ~/documentdb-cert.pem
+docker cp documentdb:/home/documentdb/.local/state/documentdb-gateway/tls/cert.pem ~/documentdb-cert.pem
 \`\`\`
 
 \`\`\`javascript
@@ -710,7 +743,7 @@ If you started with DocumentDB Local sample data, add this snippet after \`clien
 \`\`\`python
 for user in client["sampledb"]["users"].find(
     {},
-    {"_id": 0, "name": 1, "email": 1},
+    {"_id": 0, "firstName": 1, "lastName": 1, "email": 1},
 ).limit(3):
     print(user)
 \`\`\`
@@ -720,7 +753,7 @@ for user in client["sampledb"]["users"].find(
 If you want certificate validation instead of \`tlsAllowInvalidCertificates=true\`, copy the generated certificate from the container and pass it to \`MongoClient\`.
 
 \`\`\`bash
-docker cp documentdb:/home/documentdb/gateway/pg_documentdb_gw/cert.pem ~/documentdb-cert.pem
+docker cp documentdb:/home/documentdb/.local/state/documentdb-gateway/tls/cert.pem ~/documentdb-cert.pem
 \`\`\`
 
 \`\`\`python
@@ -777,7 +810,7 @@ If you prefer a host installation instead of Docker, use [Linux Packages Quick S
 
 > Replace \`<YOUR_USERNAME>\` and \`<YOUR_PASSWORD>\` with your own credentials.
 >
-> DocumentDB Local loads built-in sample data into \`sampledb\` by default. It also uses a self-signed certificate by default, so the fastest local \`mongosh\` connection adds \`--tlsAllowInvalidCertificates\`.
+> DocumentDB Local starts **empty** — pass \`--init-data true\` on the \`docker run\` above to seed the \`sampledb\` sample data used below. It also uses a self-signed certificate by default, so the fastest local \`mongosh\` connection adds \`--tlsAllowInvalidCertificates\`.
 
 ## Connect and verify the connection
 
@@ -802,14 +835,14 @@ Successful output confirms authentication, TLS, and the gateway endpoint are wor
 
 ## Explore the built-in sample data
 
-DocumentDB Local loads sample collections into \`sampledb\` by default.
+Sample data is **opt-in**: this section needs a container started with \`--init-data true\`. Without it \`sampledb\` does not exist and these queries return nothing.
 
 \`\`\`javascript
 use sampledb
 
 db.users.find(
   {},
-  { name: 1, email: 1, _id: 0 }
+  { firstName: 1, lastName: 1, email: 1, _id: 0 }
 ).limit(3)
 
 db.products.find(
@@ -845,7 +878,7 @@ If you want certificate validation instead of \`--tlsAllowInvalidCertificates\`,
 the generated certificate from the container and pass it to \`mongosh\`.
 
 \`\`\`bash
-docker cp documentdb:/home/documentdb/gateway/pg_documentdb_gw/cert.pem ~/documentdb-cert.pem
+docker cp documentdb:/home/documentdb/.local/state/documentdb-gateway/tls/cert.pem ~/documentdb-cert.pem
 
 mongosh localhost:10260 \\
   -u <YOUR_USERNAME> \\


### PR DESCRIPTION
Six reviews (Opus 5, Opus 4.8, GPT-5.6 Sol — two repos each) scored the docs against a written standard derived from [Diátaxis](https://diataxis.fr/), the CloudNativePG layout, the PostgreSQL documentation guide, and failures reproduced against DocumentDB's own published pages.

**Website mean: 29/50.** The `packages` page scored ~46 on its own; the connect guides — which never got the same cold-start treatment — dragged the rest down. Every item below was reproduced against the published `0.116.0` image.

---

## 1. The certificate command was wrong on three pages

```
docker cp documentdb:/home/documentdb/gateway/pg_documentdb_gw/cert.pem ~/documentdb-cert.pem
Error: Could not find the file ... in container
```

Real path: `/home/documentdb/.local/state/documentdb-gateway/tls/cert.pem`. One wrong string, retyped on three pages — exactly the drift a single source prevents.

## 2. "Sample data loads by default" was false

`--init-data` defaults to `false`. A container started as the guides showed returns `listDatabases → []`, so **every `use sampledb` block silently returned nothing**. The `documentdb-local` page already said the opposite ("starts **empty**"), so the two contradicted each other.

Now stated as opt-in, and stated **where the reader starts the container** rather than where they hit the empty result.

## 3. The projection referenced a field that doesn't exist

`sampledb.users` has `firstName`/`lastName`, no `name`. The documented `{ name: 1, email: 1 }` printed only the email while the prose promised names.

## 4. mongosh install broke on ARM

The RHEL repo was pinned to `.../mongodb-org/8.0/x86_64/`. This page already carries an ARM substitution table for the DocumentDB and PGDG lines — the MongoDB line was missed. Now `$(uname -m)`, matching the `EL-9-$(uname -m)` form already documented for PGDG.

## 5. Docker Quick Start: three gaps the standard treats as defects

- **Published on every interface.** `-p 10260:10260` while calling the instance "local" → now `-p 127.0.0.1:10260:10260`, with a note on when to widen it.
- **Readiness race.** The page ran `docker ps`, then immediately told the reader to connect. `docker ps` reports `Up` well before the gateway accepts connections — `documentdb-local` documents this race; this page ignored it. Now waits for `=== DocumentDB is ready ===`.
- **No day-2 lifecycle at all.** The fastest and most-recommended path had no stop/start/restart/remove. Anyone following two guides in sequence hit `Conflict. The container name "/documentdb" is already in use` with no documented recovery.

---

## Verification

- All edits confirmed in rendered output via `getArticleByPath`; the old cert path returns **zero** matches across all four guides.
- `npm test` 130 passed · `eslint` clean · `tsc --noEmit` clean.

## Note on the review process

Two of six reviewers reported a "broken URI" containing `******`. That was the credential-redaction filter masking `mongodb://user:pass@host` in their own transcripts — `******` appears nowhere in either repo. Verified against raw bytes and **discarded**; one reviewer (Opus 5) caught it independently. No finding here was acted on without confirming it in the actual file.

## Related

documentdb/docs#71 — the docs-repo half: non-functional Python samples, a vector index that cannot be created as documented, stale version floors, and five orphaned stub pages.
